### PR TITLE
clippy: Remove unused enumerate index.

### DIFF
--- a/src/editor/ui/tools/gizmo.rs
+++ b/src/editor/ui/tools/gizmo.rs
@@ -140,7 +140,7 @@ impl EditorTool for GizmoTool {
                 if gizmo_interacted && ui.input(|s| s.modifiers.alt) {
                     if self.is_move_cloned_entities {
                     } else {
-                        for (_, e) in selected.iter().enumerate() {
+                        for e in selected.iter() {
                             cell.world_mut().send_event(CloneEvent { id: *e });
                         }
                         self.is_move_cloned_entities = true;


### PR DESCRIPTION
This is from `clippy::unused_enumerate_index`, coming in Rust 1.75.