### PR TITLE
Lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --all-features
 
   # Run cargo fmt --all -- --check
   format:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install stable@1.73 toolchain
+        uses: dtolnay/rust-toolchain@1.73
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
@@ -55,8 +55,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install stable@1.73 toolchain
+        uses: dtolnay/rust-toolchain@1.73
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
@@ -80,8 +80,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install stable@1.73 toolchain
+        uses: dtolnay/rust-toolchain@1.73
         with:
           components: clippy
       - name: Install Dependencies
@@ -97,8 +97,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install stable@1.73 toolchain
+        uses: dtolnay/rust-toolchain@1.73
         with:
           components: rustfmt
       - name: Run cargo fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --no-default-features
     
   test_all:
     name: Test all features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   # Run cargo test
-  # Run cargo test
   test_minimal:
     name: Test without features
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_develop.yaml
+++ b/.github/workflows/ci_develop.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --no-default-features
     
   test_all:
     name: Test all features

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "rust-analyzer.linkedProjects": [
-        ".\\Cargo.toml"
+        "./Cargo.toml"
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ egui-gizmo = "0.12"
 bevy-scene-hook = "9"
 ron = "0.8"
 bevy_panorbit_camera = "0.9"
-bevy-inspector-egui = { path = "../bevy-inspector-egui/crates/bevy-inspector-egui", version = "0.21", features = ["bevy_pbr", "highlight_changes"]}
+bevy-inspector-egui = { version = "0.21", features = ["bevy_pbr", "highlight_changes"]}
 pretty-type-name = "1.0"
 bevy_mod_picking = {version = "0.17", default-features = false, features = ["backend_raycast", "selection"]}
 bevy_debug_grid = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ egui_file = "0.11"
 
 bevy_xpbd_3d = {version="0.3", default-features = false, optional = true}
 
+# For versions 1.74+
 [lints.rust]
 future-incompatible = "warn"
 nonstandard_style = "deny"
@@ -40,12 +41,6 @@ cognitive_complexity = { level = "allow", priority = 2 }
 needless_pass_by_ref_mut = { level = "allow", priority = 2 }
 significant_drop_in_scrutinee = { level = "allow", priority = 2 }
 significant_drop_tightening = { level = "allow", priority = 2 }
-
-
-[profile.dev]
-opt-level = 3             # Use slightly better optimizations.
-lto = "thin"
-codegen-units = 1
 
 [profile.dev.package.bevy_xpbd_3d]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ egui-gizmo = "0.12"
 bevy-scene-hook = "9"
 ron = "0.8"
 bevy_panorbit_camera = "0.9"
-bevy-inspector-egui = {version = "0.21", features = ["bevy_pbr", "highlight_changes"]}
+bevy-inspector-egui = { path = "../bevy-inspector-egui/crates/bevy-inspector-egui", version = "0.21", features = ["bevy_pbr", "highlight_changes"]}
 pretty-type-name = "1.0"
 bevy_mod_picking = {version = "0.17", default-features = false, features = ["backend_raycast", "selection"]}
 bevy_debug_grid = "0.3"
@@ -28,11 +28,31 @@ egui_file = "0.11"
 
 bevy_xpbd_3d = {version="0.3", default-features = false, optional = true}
 
+[lints.rust]
+future-incompatible = "warn"
+nonstandard_style = "deny"
+
+[lints.clippy]
+nursery = { level = "deny", priority = 0 }
+all = { level = "deny", priority = 1 }
+# Bevy Related
+cognitive_complexity = { level = "allow", priority = 2 }
+needless_pass_by_ref_mut = { level = "allow", priority = 2 }
+significant_drop_in_scrutinee = { level = "allow", priority = 2 }
+significant_drop_tightening = { level = "allow", priority = 2 }
+
+
+[profile.dev]
+opt-level = 3             # Use slightly better optimizations.
+lto = "thin"
+codegen-units = 1
+
 [profile.dev.package.bevy_xpbd_3d]
 opt-level = 3
 
 [features]
 bevy_xpbd_3d = ["dep:bevy_xpbd_3d", "bevy_xpbd_3d/debug-plugin", "bevy_xpbd_3d/3d", "bevy_xpbd_3d/collider-from-mesh", "bevy_xpbd_3d/f32"]
+default = ["bevy_xpbd_3d"]
 
 [[example]]
 name = "platformer"

--- a/src/editor/core/load.rs
+++ b/src/editor/core/load.rs
@@ -11,7 +11,7 @@ pub fn load_listener(world: &mut World) {
         if let Some(scene) = &load_server.scene {
             if let Some(scene) = assets.get(scene) {
                 let mut scene = Scene::from_dynamic_scene(scene, &app_registry).unwrap();
-                scene.world.insert_resource(app_registry.clone());
+                scene.world.insert_resource(app_registry);
                 prefab = DynamicScene::from_scene(&scene); //kill me, is it clone() analog for DynamicScene
             } else {
                 return;

--- a/src/editor/core/mod.rs
+++ b/src/editor/core/mod.rs
@@ -7,10 +7,8 @@ use load::*;
 pub mod tool;
 pub use tool::*;
 
-pub mod settings;
-pub use settings::*;
-
 pub mod gltf_unpack;
+pub mod settings;
 
 use bevy::prelude::*;
 

--- a/src/editor/core/tool.rs
+++ b/src/editor/core/tool.rs
@@ -19,10 +19,10 @@ pub enum ToolName {
 impl ToolName {
     pub fn as_str(&self) -> &str {
         match self {
-            ToolName::Gizmo => "gizmo",
+            Self::Gizmo => "gizmo",
             #[cfg(feature = "floor_plan")]
-            ToolName::FloorMap => "floor map",
-            ToolName::Other(name) => name,
+            Self::FloorMap => "floor map",
+            Self::Other(name) => name,
         }
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,6 +1,9 @@
 //code only for editor gui
 
-use bevy::{prelude::*, render::render_resource::PrimitiveTopology, window::PrimaryWindow};
+use bevy::{
+    input::common_conditions::input_toggle_active, prelude::*,
+    render::render_resource::PrimitiveTopology, window::PrimaryWindow,
+};
 
 pub mod core;
 pub mod ui;
@@ -122,7 +125,11 @@ impl Plugin for EditorPlugin {
 
         app.init_resource::<BundleReg>();
 
-        app.add_plugins(WorldInspectorPlugin::default().run_if(in_state(EditorState::Game)));
+        app.add_plugins(
+            WorldInspectorPlugin::default()
+                .run_if(in_state(EditorState::Game))
+                .run_if(input_toggle_active(false, KeyCode::Escape)),
+        );
 
         register_mesh_editor_bundles(app);
         register_light_editor_bundles(app);
@@ -215,7 +222,7 @@ fn select_listener(
 
 impl From<ListenerInput<Pointer<Down>>> for SelectEvent {
     fn from(value: ListenerInput<Pointer<Down>>) -> Self {
-        SelectEvent {
+        Self {
             e: value.target(),
             event: value,
         }

--- a/src/editor/ui/bot_menu.rs
+++ b/src/editor/ui/bot_menu.rs
@@ -46,7 +46,7 @@ fn bot_menu_game(
                 state.set(EditorState::Editor);
             }
 
-            *smoothed_dt = *smoothed_dt * 0.98 + time.delta_seconds() * 0.02;
+            *smoothed_dt = (*smoothed_dt).mul_add(0.98, time.delta_seconds() * 0.02);
             ui.label(format!("FPS: {:.0}", 1.0 / *smoothed_dt));
         });
     });
@@ -125,7 +125,7 @@ pub fn bot_menu(
                         if path.starts_with("assets/") {
                             path = path.replace("assets/", "");
 
-                            editor_events.send(EditorEvent::LoadGltfAsPrefab(path.to_string()));
+                            editor_events.send(EditorEvent::LoadGltfAsPrefab(path));
                         }
                     }
                 } else {

--- a/src/editor/ui/editor_tab.rs
+++ b/src/editor/ui/editor_tab.rs
@@ -77,18 +77,12 @@ impl<'a> egui_dock::TabViewer for EditorTabViewer<'a> {
                     show_command: _,
                     title_command,
                 } => title_command(self.world),
-                EditorUiReg::Schedule => {
-                    if let Some(tab) = self
-                        .world
-                        .resource_mut::<ScheduleEditorTabStorage>()
-                        .0
-                        .get(tab)
-                    {
-                        tab.title.clone()
-                    } else {
-                        format!("{tab:?}").into()
-                    }
-                }
+                EditorUiReg::Schedule => self
+                    .world
+                    .resource_mut::<ScheduleEditorTabStorage>()
+                    .0
+                    .get(tab)
+                    .map_or_else(|| format!("{tab:?}").into(), |tab| tab.title.clone()),
             }
         } else {
             format!("{tab:?}").into()

--- a/src/editor/ui/game_view.rs
+++ b/src/editor/ui/game_view.rs
@@ -31,7 +31,7 @@ impl EditorTab for GameViewTab {
 
         //Draw FPS
         let dt = world.get_resource::<Time>().unwrap().delta_seconds();
-        self.smoothed_dt = self.smoothed_dt * 0.98 + dt * 0.02;
+        self.smoothed_dt = self.smoothed_dt.mul_add(0.98, dt * 0.02);
         ui.colored_label(
             egui::Color32::WHITE,
             format!("FPS: {:.0}", 1.0 / self.smoothed_dt),

--- a/src/editor/ui/hierarchy.rs
+++ b/src/editor/ui/hierarchy.rs
@@ -74,17 +74,18 @@ pub fn show_hierarchy(
             }
         }
         ui.vertical_centered(|ui| {
-            if ui.button("----- + -----").clicked() {
+            ui.separator();
+            if ui.button("+ Add new entity").clicked() {
                 commands.spawn_empty().insert(PrefabMarker);
             }
-            if ui.button("Clear all").clicked() {
+            if ui.button("Clear all entities").clicked() {
                 for (entity, _, _, _parent) in all.iter() {
                     commands.entity(*entity).despawn_recursive();
                 }
             }
         });
 
-        ui.label("Spawn bundle");
+        ui.label("Spawnable bundles");
         for (cat_name, cat) in ui_reg.bundles.iter() {
             ui.menu_button(cat_name, |ui| {
                 for (name, dyn_bundle) in cat {

--- a/src/editor/ui/inspector/mod.rs
+++ b/src/editor/ui/inspector/mod.rs
@@ -260,30 +260,36 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
             ui.label("Add component");
             ui.text_edit_singleline(&mut state.component_add_filter);
             let lower_filter = state.component_add_filter.to_lowercase();
-            egui::ScrollArea::vertical().show(ui, |ui| {
-                egui::Grid::new("Component grid").show(ui, |ui| {
-                    let _counter = 0;
-                    for idx in 0..components_id.len() {
-                        let c_id = components_id[idx];
-                        let _t_id = types_id[idx];
-                        let name = pretty_type_name::pretty_type_name_str(
-                            cell.components().get_info(c_id).unwrap().name(),
-                        );
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    egui::Grid::new("Component grid").show(ui, |ui| {
+                        let _counter = 0;
+                        for idx in 0..components_id.len() {
+                            let c_id = components_id[idx];
+                            let _t_id = types_id[idx];
+                            let name = pretty_type_name::pretty_type_name_str(
+                                cell.components().get_info(c_id).unwrap().name(),
+                            );
 
-                        if name.to_lowercase().contains(&lower_filter) {
-                            ui.label(name);
-                            if ui.button("+").clicked() {
-                                let id =
-                                    cell.components().get_info(c_id).unwrap().type_id().unwrap();
-                                for e in selected.iter() {
-                                    commands.push(InspectCommand::AddComponent(*e, id));
+                            if name.to_lowercase().contains(&lower_filter) {
+                                ui.label(name);
+                                if ui.button("+").clicked() {
+                                    let id = cell
+                                        .components()
+                                        .get_info(c_id)
+                                        .unwrap()
+                                        .type_id()
+                                        .unwrap();
+                                    for e in selected.iter() {
+                                        commands.push(InspectCommand::AddComponent(*e, id));
+                                    }
                                 }
+                                ui.end_row();
                             }
-                            ui.end_row();
                         }
-                    }
+                    });
                 });
-            });
         });
 
         state.commands = commands;

--- a/src/editor/ui/inspector/mod.rs
+++ b/src/editor/ui/inspector/mod.rs
@@ -147,122 +147,120 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
     }
     components_id.sort_by(|a, b| a.2.cmp(&b.2));
 
-    unsafe {
-        let cell = world.as_unsafe_world_cell();
-        let mut state = cell.get_resource_mut::<InspectState>().unwrap();
+    let cell = world.as_unsafe_world_cell();
+    let mut state = unsafe { cell.get_resource_mut::<InspectState>().unwrap() };
 
-        let mut commands: Vec<InspectCommand> = vec![];
-        let mut queue = CommandQueue::default();
-        let mut cx = bevy_inspector_egui::reflect_inspector::Context {
+    let mut commands: Vec<InspectCommand> = vec![];
+    let mut queue = CommandQueue::default();
+    let mut cx = unsafe {
+        bevy_inspector_egui::reflect_inspector::Context {
             world: Some(cell.world_mut().into()),
             queue: Some(&mut queue),
-        };
-        let mut env = InspectorUi::for_bevy(&world_registry, &mut cx);
+        }
+    };
+    let mut env = InspectorUi::for_bevy(&world_registry, &mut cx);
 
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            for e in selected.iter() {
-                if let Some(e) = cell.get_entity(*e) {
-                    let mut name;
-                    if let Some(name_struct) = e.get::<Name>() {
-                        name = name_struct.as_str().to_string();
-                        if name.is_empty() {
-                            name = format!("{:?} (empty name)", e.id());
-                        }
-                    } else {
-                        name = format!("{:?}", e.id());
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        for e in selected.iter() {
+            if let Some(e) = cell.get_entity(*e) {
+                let mut name;
+                if let Some(name_struct) = unsafe { e.get::<Name>() } {
+                    name = name_struct.as_str().to_string();
+                    if name.is_empty() {
+                        name = format!("{:?} (empty name)", e.id());
                     }
-                    ui.heading(&name);
-                    ui.label("Components:");
-                    let e_id = e.id().index();
-                    egui::Grid::new(format!("{e_id}")).show(ui, |ui| {
-                        for (c_id, t_id, name) in &components_id {
-                            if let Some(data) = e.get_mut_by_id(*c_id) {
-                                let registration = registry.get(*t_id).unwrap();
-                                if let Some(reflect_from_ptr) =
-                                    registration.data::<ReflectFromPtr>()
-                                {
-                                    let (ptr, mut set_changed) = mut_untyped_split(data);
-
-                                    let value = reflect_from_ptr.from_ptr_mut()(ptr);
-
-                                    if !editor_registry.silent.contains(&registration.type_id()) {
-                                        ui.push_id(format!("{:?}-{}", &e.id(), &name), |ui| {
-                                            ui.collapsing(name, |ui| {
-                                                ui.push_id(
-                                                    format!("content-{:?}-{}", &e.id(), &name),
-                                                    |ui| {
-                                                        if env.ui_for_reflect_with_options(
-                                                            value,
-                                                            ui,
-                                                            ui.id(),
-                                                            &(),
-                                                        ) {
-                                                            set_changed();
-                                                        }
-                                                    },
-                                                );
-                                            });
-                                        });
-
-                                        ui.push_id(
-                                            format!("del component {:?}-{}", &e.id(), &name),
-                                            |ui| {
-                                                //must be on top
-                                                ui.with_layout(
-                                                    egui::Layout::top_down(egui::Align::Min),
-                                                    |ui| {
-                                                        if ui.button("X").clicked() {
-                                                            commands.push(
-                                                                InspectCommand::RemoveComponent(
-                                                                    e.id(),
-                                                                    *t_id,
-                                                                ),
-                                                            );
-                                                        }
-                                                    },
-                                                );
-                                            },
-                                        );
-                                        ui.end_row();
-                                    }
-                                }
-                            }
-                        }
-                    });
-
-                    ui.separator();
+                } else {
+                    name = format!("{:?}", e.id());
                 }
-            }
+                ui.heading(&name);
+                ui.label("Components:");
+                let e_id = e.id().index();
+                egui::Grid::new(format!("{e_id}")).show(ui, |ui| {
+                    for (c_id, t_id, name) in &components_id {
+                        if let Some(data) = unsafe { e.get_mut_by_id(*c_id) } {
+                            let registration = registry.get(*t_id).unwrap();
+                            if let Some(reflect_from_ptr) = registration.data::<ReflectFromPtr>() {
+                                let (ptr, mut set_changed) = mut_untyped_split(data);
 
-            ui.label("Add component");
-            ui.text_edit_singleline(&mut state.component_add_filter);
-            let lower_filter = state.component_add_filter.to_lowercase();
-            egui::ScrollArea::vertical().show(ui, |ui| {
-                egui::Grid::new("Component grid").show(ui, |ui| {
-                    let _counter = 0;
-                    for (c_id, _t_id, name) in &components_id {
-                        if name.to_lowercase().contains(&lower_filter) {
-                            ui.label(name);
-                            if ui.button("+").clicked() {
-                                let id = cell
-                                    .components()
-                                    .get_info(*c_id)
-                                    .unwrap()
-                                    .type_id()
-                                    .unwrap();
-                                for e in selected.iter() {
-                                    commands.push(InspectCommand::AddComponent(*e, id));
+                                let value = unsafe { reflect_from_ptr.from_ptr_mut()(ptr) };
+
+                                if !editor_registry.silent.contains(&registration.type_id()) {
+                                    ui.push_id(format!("{:?}-{}", &e.id(), &name), |ui| {
+                                        ui.collapsing(name, |ui| {
+                                            ui.push_id(
+                                                format!("content-{:?}-{}", &e.id(), &name),
+                                                |ui| {
+                                                    if env.ui_for_reflect_with_options(
+                                                        value,
+                                                        ui,
+                                                        ui.id(),
+                                                        &(),
+                                                    ) {
+                                                        set_changed();
+                                                    }
+                                                },
+                                            );
+                                        });
+                                    });
+
+                                    ui.push_id(
+                                        format!("del component {:?}-{}", &e.id(), &name),
+                                        |ui| {
+                                            //must be on top
+                                            ui.with_layout(
+                                                egui::Layout::top_down(egui::Align::Min),
+                                                |ui| {
+                                                    if ui.button("X").clicked() {
+                                                        commands.push(
+                                                            InspectCommand::RemoveComponent(
+                                                                e.id(),
+                                                                *t_id,
+                                                            ),
+                                                        );
+                                                    }
+                                                },
+                                            );
+                                        },
+                                    );
+                                    ui.end_row();
                                 }
                             }
-                                ui.end_row();
+                        }
+                    }
+                });
+
+                ui.separator();
+            }
+        }
+
+        ui.label("Add component");
+        ui.text_edit_singleline(&mut state.component_add_filter);
+        let lower_filter = state.component_add_filter.to_lowercase();
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::Grid::new("Component grid").show(ui, |ui| {
+                let _counter = 0;
+                for (c_id, _t_id, name) in &components_id {
+                    if name.to_lowercase().contains(&lower_filter) {
+                        ui.label(name);
+                        if ui.button("+").clicked() {
+                            let id = cell
+                                .components()
+                                .get_info(*c_id)
+                                .unwrap()
+                                .type_id()
+                                .unwrap();
+                            for e in selected.iter() {
+                                commands.push(InspectCommand::AddComponent(*e, id));
                             }
                         }
-                    });
-                });
+                        ui.end_row();
+                    }
+                }
+            });
         });
+    });
 
-        state.commands = commands;
-    }
+    state.commands = commands;
 
     if disable_pan_orbit {
         world.resource_mut::<crate::editor::PanOrbitEnabled>().0 = false;

--- a/src/editor/ui/inspector/refl_impl.rs
+++ b/src/editor/ui/inspector/refl_impl.rs
@@ -48,18 +48,13 @@ pub fn entity_ref_ui(
             egui::ComboBox::new(id, "")
                 .selected_text(format!("{:?}", value.entity))
                 .show_ui(ui, |ui| {
-                    unsafe {
-                        for e in world.world().world().iter_entities() {
-                            if ui
-                                .selectable_value(
-                                    &mut value.entity,
-                                    e.id(),
-                                    format!("{:?}", e.id()),
-                                )
-                                .clicked()
-                            {
-                                return true;
-                            }
+                    let world_ref = unsafe { world.world().world() };
+                    for e in world_ref.iter_entities() {
+                        if ui
+                            .selectable_value(&mut value.entity, e.id(), format!("{:?}", e.id()))
+                            .clicked()
+                        {
+                            return true;
                         }
                     }
                     false

--- a/src/editor/ui/inspector/refl_impl.rs
+++ b/src/editor/ui/inspector/refl_impl.rs
@@ -64,14 +64,11 @@ pub fn entity_ref_ui(
                     }
                     false
                 });
-            false
         } else {
             ui.label(format!("{:?}", &value.entity));
-            false
         }
-    } else {
-        false
     }
+    false
 }
 
 /// Custom UI for [`EntityLink`] struct

--- a/src/editor/ui/mod.rs
+++ b/src/editor/ui/mod.rs
@@ -182,42 +182,40 @@ impl EditorUi {
 
         let cell = world.as_unsafe_world_cell();
 
-        unsafe {
-            let mut command_queue = CommandQueue::default();
-            let mut commands = Commands::new(&mut command_queue, cell.world());
+        let mut command_queue = CommandQueue::default();
+        let mut commands = unsafe { Commands::new(&mut command_queue, cell.world()) };
 
-            let mut tab_viewer = EditorTabViewer {
-                commands: &mut commands,
-                world: cell.world_mut(),
-                registry: &mut self.registry,
-                visible,
-                tab_commands: vec![],
-            };
+        let mut tab_viewer = EditorTabViewer {
+            commands: &mut commands,
+            world: unsafe { cell.world_mut() },
+            registry: &mut self.registry,
+            visible,
+            tab_commands: vec![],
+        };
 
-            DockArea::new(&mut self.tree)
-                .show_add_buttons(true)
-                .show_add_popup(true)
-                .show(ctx, &mut tab_viewer);
+        DockArea::new(&mut self.tree)
+            .show_add_buttons(true)
+            .show_add_popup(true)
+            .show(ctx, &mut tab_viewer);
 
-            for command in tab_viewer.tab_commands {
-                match command {
-                    EditorTabCommand::Add {
-                        name,
-                        surface,
-                        node,
-                    } => {
-                        if let Some(surface) = self.tree.get_surface_mut(surface) {
-                            surface
-                                .node_tree_mut()
-                                .unwrap()
-                                .split_right(node, 0.5, vec![name]);
-                        }
+        for command in tab_viewer.tab_commands {
+            match command {
+                EditorTabCommand::Add {
+                    name,
+                    surface,
+                    node,
+                } => {
+                    if let Some(surface) = self.tree.get_surface_mut(surface) {
+                        surface
+                            .node_tree_mut()
+                            .unwrap()
+                            .split_right(node, 0.5, vec![name]);
                     }
                 }
             }
-
-            command_queue.apply(cell.world_mut());
         }
+
+        command_queue.apply(unsafe { cell.world_mut() });
     }
 }
 

--- a/src/editor/ui/tools/gizmo.rs
+++ b/src/editor/ui/tools/gizmo.rs
@@ -97,187 +97,184 @@ impl EditorTool for GizmoTool {
         let mut disable_pan_orbit = false;
         let _gizmo_mode = GizmoMode::Translate;
 
-        unsafe {
-            let cell = world.as_unsafe_world_cell();
+        let cell = world.as_unsafe_world_cell();
 
-            let view_matrix = Mat4::from(cam_transform.affine().inverse());
-            if ui.input(|s| s.modifiers.shift) {
-                let mut mean_transform = Transform::IDENTITY;
-                for e in &selected {
-                    let Some(ecell) = cell.get_entity(*e) else {
-                        continue;
-                    };
-                    let Some(global_transform) = ecell.get_mut::<GlobalTransform>() else {
-                        continue;
-                    };
-                    let tr = global_transform.compute_transform();
-                    mean_transform.translation += tr.translation;
-                    mean_transform.scale += tr.scale;
-                }
-                mean_transform.translation /= selected.len() as f32;
-                mean_transform.scale /= selected.len() as f32;
+        let view_matrix = Mat4::from(cam_transform.affine().inverse());
+        if ui.input(|s| s.modifiers.shift) {
+            let mut mean_transform = Transform::IDENTITY;
+            for e in &selected {
+                let Some(ecell) = cell.get_entity(*e) else {
+                    continue;
+                };
+                let Some(global_transform) = (unsafe { ecell.get_mut::<GlobalTransform>() }) else {
+                    continue;
+                };
+                let tr = global_transform.compute_transform();
+                mean_transform.translation += tr.translation;
+                mean_transform.scale += tr.scale;
+            }
+            mean_transform.translation /= selected.len() as f32;
+            mean_transform.scale /= selected.len() as f32;
 
-                let mut global_mean = GlobalTransform::from(mean_transform);
+            let mut global_mean = GlobalTransform::from(mean_transform);
 
-                let mut loc_transform = vec![];
-                for e in &selected {
-                    let Some(ecell) = cell.get_entity(*e) else {
-                        continue;
-                    };
-                    let Some(global_transform) = ecell.get_mut::<GlobalTransform>() else {
-                        continue;
-                    };
-                    loc_transform.push(global_transform.reparented_to(&global_mean));
-                }
+            let mut loc_transform = vec![];
+            for e in &selected {
+                let Some(ecell) = cell.get_entity(*e) else {
+                    continue;
+                };
+                let Some(global_transform) = (unsafe { ecell.get_mut::<GlobalTransform>() }) else {
+                    continue;
+                };
+                loc_transform.push(global_transform.reparented_to(&global_mean));
+            }
 
-                let mut gizmo_interacted = false;
+            let mut gizmo_interacted = false;
 
-                if let Some(result) =
-                    egui_gizmo::Gizmo::new("Selected gizmo mean global".to_string())
-                        .projection_matrix(cam_proj.get_projection_matrix().to_cols_array_2d())
-                        .view_matrix(view_matrix.to_cols_array_2d())
-                        .model_matrix(mean_transform.compute_matrix().to_cols_array_2d())
-                        .mode(self.gizmo_mode)
-                        .interact(ui)
-                {
-                    gizmo_interacted = true;
-                    mean_transform = Transform {
-                        translation: Vec3::from(<[f32; 3]>::from(result.translation)),
-                        rotation: Quat::from_array(<[f32; 4]>::from(result.rotation)),
-                        scale: Vec3::from(<[f32; 3]>::from(result.scale)),
-                    };
-                    disable_pan_orbit = true;
-                }
+            if let Some(result) = egui_gizmo::Gizmo::new("Selected gizmo mean global".to_string())
+                .projection_matrix(cam_proj.get_projection_matrix().to_cols_array_2d())
+                .view_matrix(view_matrix.to_cols_array_2d())
+                .model_matrix(mean_transform.compute_matrix().to_cols_array_2d())
+                .mode(self.gizmo_mode)
+                .interact(ui)
+            {
+                gizmo_interacted = true;
+                mean_transform = Transform {
+                    translation: Vec3::from(<[f32; 3]>::from(result.translation)),
+                    rotation: Quat::from_array(<[f32; 4]>::from(result.rotation)),
+                    scale: Vec3::from(<[f32; 3]>::from(result.scale)),
+                };
+                disable_pan_orbit = true;
+            }
 
-                global_mean = GlobalTransform::from(mean_transform);
+            global_mean = GlobalTransform::from(mean_transform);
 
-                if gizmo_interacted && ui.input(|s| s.modifiers.alt) {
-                    if self.is_move_cloned_entities {
-                    } else {
-                        for e in selected.iter() {
-                            cell.world_mut().send_event(CloneEvent { id: *e });
-                        }
-                        self.is_move_cloned_entities = true;
-                        return;
+            if gizmo_interacted && ui.input(|s| s.modifiers.alt) {
+                if self.is_move_cloned_entities {
+                } else {
+                    for e in selected.iter() {
+                        unsafe { cell.world_mut().send_event(CloneEvent { id: *e }) };
                     }
+                    self.is_move_cloned_entities = true;
+                    return;
                 }
+            }
 
-                for (idx, e) in selected.iter().enumerate() {
-                    let Some(ecell) = cell.get_entity(*e) else {
-                        continue;
-                    };
-                    let Some(mut transform) = ecell.get_mut::<Transform>() else {
-                        continue;
-                    };
+            for (idx, e) in selected.iter().enumerate() {
+                let Some(ecell) = cell.get_entity(*e) else {
+                    continue;
+                };
+                let Some(mut transform) = (unsafe { ecell.get_mut::<Transform>() }) else {
+                    continue;
+                };
 
-                    let new_global = global_mean.mul_transform(loc_transform[idx]);
+                let new_global = global_mean.mul_transform(loc_transform[idx]);
 
-                    if let Some(parent) = ecell.get::<Parent>() {
-                        if let Some(parent) = cell.get_entity(parent.get()) {
-                            if let Some(parent_global) = parent.get::<GlobalTransform>() {
-                                *transform = new_global.reparented_to(parent_global);
-                            }
+                if let Some(parent) = unsafe { ecell.get::<Parent>() } {
+                    if let Some(parent) = cell.get_entity(parent.get()) {
+                        if let Some(parent_global) = unsafe { parent.get::<GlobalTransform>() } {
+                            *transform = new_global.reparented_to(parent_global);
                         }
-                    } else {
-                        *transform = new_global.compute_transform();
                     }
+                } else {
+                    *transform = new_global.compute_transform();
                 }
-            } else {
-                for e in &selected {
-                    let Some(ecell) = cell.get_entity(*e) else {
-                        continue;
-                    };
-                    let Some(mut transform) = ecell.get_mut::<Transform>() else {
-                        continue;
-                    };
-                    if let Some(parent) = ecell.get::<Parent>() {
-                        if let Some(parent) = cell.get_entity(parent.get()) {
-                            if let Some(parent_global) = parent.get::<GlobalTransform>() {
-                                if let Some(global) = ecell.get::<GlobalTransform>() {
-                                    if let Some(result) =
-                                        egui_gizmo::Gizmo::new(format!("Selected gizmo {:?}", *e))
-                                            .projection_matrix(
-                                                cam_proj.get_projection_matrix().to_cols_array_2d(),
-                                            )
-                                            .view_matrix(view_matrix.to_cols_array_2d())
-                                            .model_matrix(
-                                                global.compute_matrix().to_cols_array_2d(),
-                                            )
-                                            .mode(self.gizmo_mode)
-                                            .interact(ui)
-                                    {
-                                        let new_transform = Transform {
-                                            translation: Vec3::from(<[f32; 3]>::from(
-                                                result.translation,
-                                            )),
-                                            rotation: Quat::from_array(<[f32; 4]>::from(
-                                                result.rotation,
-                                            )),
-                                            scale: Vec3::from(<[f32; 3]>::from(result.scale)),
-                                        };
+            }
+        } else {
+            for e in &selected {
+                let Some(ecell) = cell.get_entity(*e) else {
+                    continue;
+                };
+                let Some(mut transform) = (unsafe { ecell.get_mut::<Transform>() }) else {
+                    continue;
+                };
+                if let Some(parent) = unsafe { ecell.get::<Parent>() } {
+                    if let Some(parent) = cell.get_entity(parent.get()) {
+                        if let Some(parent_global) = unsafe { parent.get::<GlobalTransform>() } {
+                            if let Some(global) = unsafe { ecell.get::<GlobalTransform>() } {
+                                if let Some(result) =
+                                    egui_gizmo::Gizmo::new(format!("Selected gizmo {:?}", *e))
+                                        .projection_matrix(
+                                            cam_proj.get_projection_matrix().to_cols_array_2d(),
+                                        )
+                                        .view_matrix(view_matrix.to_cols_array_2d())
+                                        .model_matrix(global.compute_matrix().to_cols_array_2d())
+                                        .mode(self.gizmo_mode)
+                                        .interact(ui)
+                                {
+                                    let new_transform = Transform {
+                                        translation: Vec3::from(<[f32; 3]>::from(
+                                            result.translation,
+                                        )),
+                                        rotation: Quat::from_array(<[f32; 4]>::from(
+                                            result.rotation,
+                                        )),
+                                        scale: Vec3::from(<[f32; 3]>::from(result.scale)),
+                                    };
 
-                                        if ui.input(|s| s.modifiers.alt) {
-                                            if self.is_move_cloned_entities {
-                                                let new_transform =
-                                                    GlobalTransform::from(new_transform);
-                                                *transform =
-                                                    new_transform.reparented_to(parent_global);
-                                                transform.set_changed();
-                                                disable_pan_orbit = true;
-                                            } else {
-                                                cell.world_mut().send_event(CloneEvent { id: *e });
-                                                self.is_move_cloned_entities = true;
-                                            }
-                                        } else {
+                                    if ui.input(|s| s.modifiers.alt) {
+                                        if self.is_move_cloned_entities {
                                             let new_transform =
                                                 GlobalTransform::from(new_transform);
                                             *transform = new_transform.reparented_to(parent_global);
                                             transform.set_changed();
                                             disable_pan_orbit = true;
+                                        } else {
+                                            unsafe {
+                                                cell.world_mut().send_event(CloneEvent { id: *e })
+                                            };
+                                            self.is_move_cloned_entities = true;
                                         }
+                                    } else {
+                                        let new_transform = GlobalTransform::from(new_transform);
+                                        *transform = new_transform.reparented_to(parent_global);
+                                        transform.set_changed();
+                                        disable_pan_orbit = true;
                                     }
-                                    continue;
                                 }
+                                continue;
                             }
                         }
                     }
-                    if let Some(result) = egui_gizmo::Gizmo::new(format!("Selected gizmo {:?}", *e))
-                        .projection_matrix(cam_proj.get_projection_matrix().to_cols_array_2d())
-                        .view_matrix(view_matrix.to_cols_array_2d())
-                        .model_matrix(transform.compute_matrix().to_cols_array_2d())
-                        .mode(self.gizmo_mode)
-                        .interact(ui)
-                    {
-                        if ui.input(|s| s.modifiers.alt) {
-                            if self.is_move_cloned_entities {
-                                *transform = Transform {
-                                    translation: Vec3::from(<[f32; 3]>::from(result.translation)),
-                                    rotation: Quat::from_array(<[f32; 4]>::from(result.rotation)),
-                                    scale: Vec3::from(<[f32; 3]>::from(result.scale)),
-                                };
-                                transform.set_changed();
-                            } else {
-                                cell.world_mut().send_event(CloneEvent { id: *e });
-                                self.is_move_cloned_entities = true;
-                            }
-                        } else {
+                }
+                if let Some(result) = egui_gizmo::Gizmo::new(format!("Selected gizmo {:?}", *e))
+                    .projection_matrix(cam_proj.get_projection_matrix().to_cols_array_2d())
+                    .view_matrix(view_matrix.to_cols_array_2d())
+                    .model_matrix(transform.compute_matrix().to_cols_array_2d())
+                    .mode(self.gizmo_mode)
+                    .interact(ui)
+                {
+                    if ui.input(|s| s.modifiers.alt) {
+                        if self.is_move_cloned_entities {
                             *transform = Transform {
                                 translation: Vec3::from(<[f32; 3]>::from(result.translation)),
                                 rotation: Quat::from_array(<[f32; 4]>::from(result.rotation)),
                                 scale: Vec3::from(<[f32; 3]>::from(result.scale)),
                             };
                             transform.set_changed();
+                        } else {
+                            unsafe { cell.world_mut().send_event(CloneEvent { id: *e }) };
+                            self.is_move_cloned_entities = true;
                         }
-                        disable_pan_orbit = true;
+                    } else {
+                        *transform = Transform {
+                            translation: Vec3::from(<[f32; 3]>::from(result.translation)),
+                            rotation: Quat::from_array(<[f32; 4]>::from(result.rotation)),
+                            scale: Vec3::from(<[f32; 3]>::from(result.scale)),
+                        };
+                        transform.set_changed();
                     }
+                    disable_pan_orbit = true;
                 }
             }
+        }
 
-            if disable_pan_orbit {
+        if disable_pan_orbit {
+            unsafe {
                 cell.get_resource_mut::<crate::editor::PanOrbitEnabled>()
                     .unwrap()
-                    .0 = false;
-            }
+                    .0 = false
+            };
         }
     }
 }

--- a/src/editor/ui_registration.rs
+++ b/src/editor/ui_registration.rs
@@ -17,7 +17,7 @@ impl BundleReg {
         self.bundles
             .entry(bundle.category)
             .or_default()
-            .insert(bundle.name.clone(), dyn_bundle);
+            .insert(bundle.name, dyn_bundle);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// Both will be deprecated soon
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
@@ -20,6 +21,7 @@ use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 
 use bevy_mod_picking::{backends::raycast::RaycastPickable, PickableBundle};
 use editor::EditorPlugin;
+#[cfg(feature = "bevy_xpbd_3d")]
 use optional::OptionalPlugin;
 use prefab::PrefabPlugin;
 
@@ -121,7 +123,7 @@ pub fn simple_editor_setup(mut commands: Commands) {
             ..default()
         },
         transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
-        cascade_shadow_config: CascadeShadowConfigBuilder { ..default() }.into(),
+        cascade_shadow_config: CascadeShadowConfigBuilder::default().into(),
         ..default()
     });
 

--- a/src/optional/bevy_xpbd_plugin/collider.rs
+++ b/src/optional/bevy_xpbd_plugin/collider.rs
@@ -28,7 +28,7 @@ pub struct ColliderPrefabCompound {
 
 impl Default for ColliderPrefab {
     fn default() -> Self {
-        ColliderPrefab::Primitive {
+        Self::Primitive {
             pos: Vector::default(),
             rot: Vector::default(),
             primitive: ColliderPrimitive::Cuboid(Vector::ONE),
@@ -82,24 +82,22 @@ pub enum ColliderPrimitive {
 
 impl Default for ColliderPrimitive {
     fn default() -> Self {
-        ColliderPrimitive::Cuboid(Vector::new(1.0, 1.0, 1.0))
+        Self::Cuboid(Vector::new(1.0, 1.0, 1.0))
     }
 }
 
 impl ColliderPrimitive {
     pub fn to_collider(&self) -> Collider {
         match self {
-            ColliderPrimitive::Cuboid(bbox) => Collider::cuboid(bbox.x, bbox.y, bbox.z),
-            ColliderPrimitive::Capsule { height, radius } => Collider::capsule(*height, *radius),
-            ColliderPrimitive::CapsuleEndpoints { a, b, radius } => {
-                Collider::capsule_endpoints(*a, *b, *radius)
-            }
-            ColliderPrimitive::Cone { height, radius } => Collider::cone(*height, *radius),
-            ColliderPrimitive::Cylinder { height, radius } => Collider::cylinder(*height, *radius),
-            ColliderPrimitive::Halfspace { outward_normal } => Collider::halfspace(*outward_normal),
-            ColliderPrimitive::Triangle { a, b, c } => Collider::triangle(*a, *b, *c),
-            ColliderPrimitive::Ball(radius) => Collider::ball(*radius),
-            ColliderPrimitive::Segment { a, b } => Collider::segment(*a, *b),
+            Self::Cuboid(bbox) => Collider::cuboid(bbox.x, bbox.y, bbox.z),
+            Self::Capsule { height, radius } => Collider::capsule(*height, *radius),
+            Self::CapsuleEndpoints { a, b, radius } => Collider::capsule_endpoints(*a, *b, *radius),
+            Self::Cone { height, radius } => Collider::cone(*height, *radius),
+            Self::Cylinder { height, radius } => Collider::cylinder(*height, *radius),
+            Self::Halfspace { outward_normal } => Collider::halfspace(*outward_normal),
+            Self::Triangle { a, b, c } => Collider::triangle(*a, *b, *c),
+            Self::Ball(radius) => Collider::ball(*radius),
+            Self::Segment { a, b } => Collider::segment(*a, *b),
         }
     }
 }
@@ -165,23 +163,13 @@ fn get_collider(
     prefab_mesh: Option<&MeshPrimitivePrefab>,
 ) -> Collider {
     match collider {
-        ColliderPrefab::FromMesh => {
-            if let Some(mesh) = mesh {
-                if let Some(mesh) = meshes.get(mesh) {
-                    Collider::trimesh_from_mesh(mesh).unwrap_or_default()
-                } else {
-                    Collider::default()
-                }
-            } else {
-                Collider::default()
-            }
-        }
+        ColliderPrefab::FromMesh => mesh.map_or_else(Collider::default, |mesh| {
+            meshes.get(mesh).map_or_else(Collider::default, |mesh| {
+                Collider::trimesh_from_mesh(mesh).unwrap_or_default()
+            })
+        }),
         ColliderPrefab::FromPrefabMesh => {
-            if let Some(mesh) = prefab_mesh {
-                get_prefab_mesh_collider(mesh)
-            } else {
-                Collider::default()
-            }
+            prefab_mesh.map_or_else(Collider::default, get_prefab_mesh_collider)
         }
         ColliderPrefab::Primitive {
             pos,

--- a/src/optional/bevy_xpbd_plugin/mod.rs
+++ b/src/optional/bevy_xpbd_plugin/mod.rs
@@ -103,15 +103,15 @@ pub enum RigidBodyPrefab {
 }
 
 impl RigidBodyPrefab {
-    pub fn to_rigidbody(&self) -> RigidBody {
+    pub const fn to_rigidbody(&self) -> RigidBody {
         match self {
-            RigidBodyPrefab::Dynamic => RigidBody::Dynamic,
-            RigidBodyPrefab::Static => RigidBody::Static,
-            RigidBodyPrefab::Kinematic => RigidBody::Kinematic,
+            Self::Dynamic => RigidBody::Dynamic,
+            Self::Static => RigidBody::Static,
+            Self::Kinematic => RigidBody::Kinematic,
         }
     }
 
-    pub fn to_rigidbody_editor(&self) -> RigidBody {
+    pub const fn to_rigidbody_editor(&self) -> RigidBody {
         RigidBody::Static
     }
 }

--- a/src/optional/bevy_xpbd_plugin/spatial_query.rs
+++ b/src/optional/bevy_xpbd_plugin/spatial_query.rs
@@ -44,7 +44,7 @@ impl Default for RayCasterPrefab {
 
 impl From<RayCasterPrefab> for RayCaster {
     fn from(val: RayCasterPrefab) -> Self {
-        RayCaster::new(val.origin, val.direction)
+        Self::new(val.origin, val.direction)
     }
 }
 
@@ -89,7 +89,7 @@ pub struct ShapeCasterPrefab {
 
 impl From<ShapeCasterPrefab> for ShapeCaster {
     fn from(val: ShapeCasterPrefab) -> Self {
-        ShapeCaster::new(
+        Self::new(
             val.shape.to_collider(),
             val.origin,
             val.shape_rotation,

--- a/src/optional/mod.rs
+++ b/src/optional/mod.rs
@@ -4,11 +4,12 @@ use bevy::prelude::*;
 pub mod bevy_xpbd_plugin;
 
 //add optional dependencies
+#[cfg(feature = "bevy_xpbd_3d")]
 pub struct OptionalPlugin;
 
+#[cfg(feature = "bevy_xpbd_3d")]
 impl Plugin for OptionalPlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(feature = "bevy_xpbd_3d")]
         {
             info!("Add bevy_xpbd_3d plugin to editor");
             app.add_plugins(bevy_xpbd_plugin::BevyXpbdPlugin);

--- a/src/prefab/component/mod.rs
+++ b/src/prefab/component/mod.rs
@@ -10,11 +10,8 @@ pub use camera::*;
 pub mod player_start;
 pub use player_start::*;
 
-pub mod path;
-pub use path::*;
-
 pub mod light;
-pub use light::*;
+pub mod path;
 
 use bevy::{prelude::*, reflect::*, utils::HashMap};
 
@@ -48,13 +45,13 @@ pub struct SceneAutoChild;
 /// Not used right now. Planned to be easy method for creating prefab structs from usual structs with assets
 #[derive(Component, Reflect, Clone, Default)]
 #[reflect(Component)]
-pub struct AutoStruct<T: Reflect + FromReflect + Default + Clone> {
+pub struct AutoStruct<T: Reflect + Default + Clone> {
     pub data: T,
     pub asset_paths: HashMap<String, String>,
 }
 
 impl<T: Reflect + FromReflect + Default + Clone> AutoStruct<T> {
-    pub fn new(data: &T, _assets: &AssetServer) -> AutoStruct<T> {
+    pub fn new(data: &T, _assets: &AssetServer) -> Self {
         let mut paths = HashMap::new();
 
         if let ReflectRef::Struct(s) = data.reflect_ref() {
@@ -70,7 +67,7 @@ impl<T: Reflect + FromReflect + Default + Clone> AutoStruct<T> {
             }
         }
 
-        AutoStruct::<T> {
+        Self {
             data: data.clone(),
             asset_paths: paths,
         }
@@ -83,6 +80,7 @@ impl<T: Reflect + FromReflect + Default + Clone> AutoStruct<T> {
             if let ReflectMut::Struct(s) = res_reflect.reflect_mut() {
                 for (field_name, path) in self.asset_paths.iter() {
                     if let Some(field) = s.field_mut(field_name) {
+                        #[allow(clippy::option_if_let_else)]
                         if let Some(handle) = field.downcast_mut::<Handle<Image>>() {
                             *handle = assets.load(path);
                         } else if let Some(handle) = field.downcast_mut::<Handle<Mesh>>() {

--- a/src/prefab/component/shape.rs
+++ b/src/prefab/component/shape.rs
@@ -19,7 +19,7 @@ pub enum MeshPrimitivePrefab {
 
 impl Default for MeshPrimitivePrefab {
     fn default() -> Self {
-        MeshPrimitivePrefab::Box(BoxPrefab {
+        Self::Box(BoxPrefab {
             w: 1.0,
             h: 1.0,
             d: 1.0,
@@ -31,17 +31,17 @@ impl MeshPrimitivePrefab {
     /// Convert [`MeshPrimitivePrefab`] to bevy [`Mesh`]
     pub fn to_mesh(&self) -> Mesh {
         match self {
-            MeshPrimitivePrefab::Cube(s) => Mesh::from(shape::Cube::new(*s)),
-            MeshPrimitivePrefab::Box(b) => b.to_mesh(),
-            MeshPrimitivePrefab::Sphere(s) => s.to_mesh(),
-            MeshPrimitivePrefab::Quad(q) => q.to_mesh(),
-            MeshPrimitivePrefab::Capsule(c) => c.to_mesh(),
-            MeshPrimitivePrefab::Circle(c) => c.to_mesh(),
-            MeshPrimitivePrefab::Cylinder(c) => c.to_mesh(),
-            MeshPrimitivePrefab::Icosphere(c) => c.to_mesh(),
-            MeshPrimitivePrefab::Plane(c) => c.to_mesh(),
-            MeshPrimitivePrefab::RegularPolygon(c) => c.to_mesh(),
-            MeshPrimitivePrefab::Torus(c) => c.to_mesh(),
+            Self::Cube(s) => Mesh::from(shape::Cube::new(*s)),
+            Self::Box(b) => b.to_mesh(),
+            Self::Sphere(s) => s.to_mesh(),
+            Self::Quad(q) => q.to_mesh(),
+            Self::Capsule(c) => c.to_mesh(),
+            Self::Circle(c) => c.to_mesh(),
+            Self::Cylinder(c) => c.to_mesh(),
+            Self::Icosphere(c) => c.to_mesh(),
+            Self::Plane(c) => c.to_mesh(),
+            Self::RegularPolygon(c) => c.to_mesh(),
+            Self::Torus(c) => c.to_mesh(),
         }
     }
 }
@@ -237,11 +237,10 @@ impl IcospherePrefab {
             radius: self.r,
             subdivisions: self.subdivisions,
         };
-        if let Ok(mesh) = Mesh::try_from(data) {
-            mesh
-        } else {
-            Mesh::try_from(shape::Icosphere::default()).unwrap()
-        }
+        Mesh::try_from(data).map_or_else(
+            |_| Mesh::try_from(shape::Icosphere::default()).unwrap(),
+            |mesh| mesh,
+        )
     }
 }
 

--- a/src/prefab/mod.rs
+++ b/src/prefab/mod.rs
@@ -23,10 +23,12 @@ use bevy::{
 use bevy_scene_hook::HookPlugin;
 
 use crate::{
-    editor_registry::EditorRegistryExt,
-    prelude::{EditorRegistryPlugin, OptionalPlugin},
-    EditorSet, EditorState, PrefabMarker, PrefabSet,
+    editor_registry::EditorRegistryExt, prelude::EditorRegistryPlugin, EditorSet, EditorState,
+    PrefabMarker, PrefabSet,
 };
+
+#[cfg(feature = "bevy_xpbd_3d")]
+use crate::prelude::OptionalPlugin;
 
 use component::*;
 use load::*;
@@ -39,6 +41,7 @@ pub struct PrefabPlugin;
 impl Plugin for PrefabPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(BasePrefabPlugin);
+        #[cfg(feature = "bevy_xpbd_3d")]
         app.add_plugins(OptionalPlugin);
     }
 }


### PR DESCRIPTION
- Added default lint configuration and applied some extra lints
- Reduced the area that unsafe blocks were touching
- Renamed some buttons to improve understanding.
- In game mode, inspector only show if esc is pressed, maybe we can change it to F1 
![image](https://github.com/rewin123/space_editor/assets/14813660/35fa91ab-6ff7-4a09-a199-173c961c985a)

> I had to set dtolnay/rust-toolchain to version 1.73, because version 1.74 has a MIR crash on [bevy-inspector](https://github.com/jakobhellermann/bevy-inspector-egui/issues/163) 

Things I plan to do (unordered):
- [ ] Study other editor components
- [ ] Add support for Rapier
- [ ] Add component become a right click event on the inspector window (or a tab)
- [ ] Make a crates folder with xpbd and prefab
- [ ] Improve component naming
- [ ] Currently when we add a new tab we split the dock region, I want them to append to the dock tab  
![image](https://github.com/rewin123/space_editor/assets/14813660/12a047ce-32b3-4ff2-8e7f-20014467ce00)
- [ ] Camera view