### PR TITLE
Change Rotate/Translate/Scale in GameView  to icons

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -18,8 +18,8 @@ Shortcuts to manipulate the gizmo:
 - **LClick**: Move/Rotate/Scale one entity.
 - **Shift + LClick**: Move/Rotate/Scale multiple entities with the "geometric mean" gizmo.
 - **R**: Change gizmo mode to "Rotate".
-- **G**: Change gizmo mode to "Move".
-- **S**: Change gizmo mode to "Scale".
+- **T**: Change gizmo mode to "Translate/Move".
+- **Y**: Change gizmo mode to "Scale".
 
 # Hierarchy
 

--- a/src/editor/ui/tools/gizmo.rs
+++ b/src/editor/ui/tools/gizmo.rs
@@ -35,27 +35,38 @@ impl EditorTool for GizmoTool {
         // If SHIFT+ALT pressed, then all selected entities will be cloned at interact
 
         let mode2name = vec![
-            (GizmoMode::Translate, "Translate"),
-            (GizmoMode::Rotate, "Rotate"),
-            (GizmoMode::Scale, "Scale"),
+            (GizmoMode::Translate, "⬌", "Translate"),
+            (GizmoMode::Rotate, "↺", "Rotate"),
+            (GizmoMode::Scale, "⛶", "Scale"),
         ];
 
-        for (mode, name) in mode2name {
-            if self.gizmo_mode == mode {
-                ui.button(egui::RichText::new(name).strong()).clicked();
-            } else if ui.button(name).clicked() {
-                self.gizmo_mode = mode;
+        ui.spacing();
+        ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
+            for (mode, name, hint) in mode2name {
+                if self.gizmo_mode == mode {
+                    ui.button(egui::RichText::new(name).strong())
+                        .on_disabled_hover_text(hint)
+                        .on_hover_text(hint)
+                        .clicked();
+                } else if ui
+                    .button(name)
+                    .on_disabled_hover_text(hint)
+                    .on_hover_text(hint)
+                    .clicked()
+                {
+                    self.gizmo_mode = mode;
+                }
             }
-        }
+        });
 
         let mut del = false;
 
         if ui.ui_contains_pointer() && !ui.ctx().wants_keyboard_input() {
             //hot keys. Blender keys preffer
             let mode2key = vec![
-                (GizmoMode::Translate, Key::G),
+                (GizmoMode::Translate, Key::T),
                 (GizmoMode::Rotate, Key::R),
-                (GizmoMode::Scale, Key::S),
+                (GizmoMode::Scale, Key::Y),
             ];
 
             for (mode, key) in mode2key {


### PR DESCRIPTION
- change key bindings to R/T/Y (Rotate/Translate/Scale)
<img width="194" alt="Captura de Tela 2023-11-22 às 11 01 05 PM" src="https://github.com/rewin123/space_editor/assets/14813660/d28aa5cb-5c3e-4a35-8bdd-2e1f3f04f223">
<img width="196" alt="Captura de Tela 2023-11-22 às 11 01 12 PM" src="https://github.com/rewin123/space_editor/assets/14813660/5a47a350-74b2-41bc-958a-2d964f0b7e67">
<img width="189" alt="Captura de Tela 2023-11-22 às 11 01 21 PM" src="https://github.com/rewin123/space_editor/assets/14813660/705eba25-303b-44f4-a88e-2af853434469">

This is something that crossed my mind while using Unity today

What do you think?