### PR TITLE
Store components state for each entity

### DIFF
--- a/src/editor/ui/inspector/mod.rs
+++ b/src/editor/ui/inspector/mod.rs
@@ -8,6 +8,7 @@ use bevy::{
     prelude::*,
     ptr::PtrMut,
     reflect::ReflectFromPtr,
+    utils::HashMap,
 };
 
 use bevy_egui::*;
@@ -55,11 +56,13 @@ impl Plugin for SpaceInspectorPlugin {
 }
 
 #[derive(Resource, Default)]
-pub struct InspectorTab {}
+pub struct InspectorTab {
+    open_components: HashMap<String, bool>,
+}
 
 impl EditorTab for InspectorTab {
     fn ui(&mut self, ui: &mut egui::Ui, _: &mut Commands, world: &mut World) {
-        inspect(ui, world);
+        inspect(ui, world, &mut self.open_components);
     }
 
     fn title(&self) -> egui::WidgetText {
@@ -126,7 +129,7 @@ fn execute_inspect_command(
 }
 
 /// System to show inspector panel
-pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
+pub fn inspect(ui: &mut egui::Ui, world: &mut World, open_components: &mut HashMap<String, bool>) {
     let selected_entity = world
         .query_filtered::<Entity, With<Selected>>()
         .get_single(world);
@@ -207,21 +210,28 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
 
                             if !editor_registry.silent.contains(&registration.type_id()) {
                                 ui.push_id(format!("{:?}-{}", &e.id(), &name), |ui| {
-                                    ui.collapsing(name, |ui| {
-                                        ui.push_id(
-                                            format!("content-{:?}-{}", &e.id(), &name),
-                                            |ui| {
-                                                if env.ui_for_reflect_with_options(
-                                                    value,
-                                                    ui,
-                                                    ui.id(),
-                                                    &(),
-                                                ) {
-                                                    set_changed();
-                                                }
-                                            },
-                                        );
-                                    });
+                                    let header = egui::CollapsingHeader::new(name)
+                                        .default_open(*open_components.get(name).unwrap_or(&false))
+                                        .show(ui, |ui| {
+                                            ui.push_id(
+                                                format!("content-{:?}-{}", &e.id(), &name),
+                                                |ui| {
+                                                    if env.ui_for_reflect_with_options(
+                                                        value,
+                                                        ui,
+                                                        ui.id(),
+                                                        &(),
+                                                    ) {
+                                                        set_changed();
+                                                    }
+                                                },
+                                            );
+                                        });
+                                    if header.header_response.clicked() {
+                                        let open_name =
+                                            open_components.entry(name.clone()).or_default();
+                                        *open_name = header.fully_open();
+                                    }
                                 });
 
                                 ui.push_id(

--- a/src/editor/ui/tools/gizmo.rs
+++ b/src/editor/ui/tools/gizmo.rs
@@ -34,12 +34,12 @@ pub enum GizmoHotkey {
 impl Hotkey for GizmoHotkey {
     fn name<'a>(&self) -> String {
         match self {
-            GizmoHotkey::Translate => "Translate entity".to_string(),
-            GizmoHotkey::Rotate => "Rotate entity".to_string(),
-            GizmoHotkey::Scale => "Scale entity".to_string(),
-            GizmoHotkey::Delete => "Delete entity".to_string(),
-            GizmoHotkey::Multiple => "Change multiple entities".to_string(),
-            GizmoHotkey::Clone => "Clone entity".to_string(),
+            Self::Translate => "Translate entity".to_string(),
+            Self::Rotate => "Rotate entity".to_string(),
+            Self::Scale => "Scale entity".to_string(),
+            Self::Delete => "Delete entity".to_string(),
+            Self::Multiple => "Change multiple entities".to_string(),
+            Self::Clone => "Clone entity".to_string(),
         }
     }
 }


### PR DESCRIPTION
This is an accidental interesting solution for issue #52.

The inspector tab stores the state (open/close) for each component per entity. Which means:
"If entity B has components Name and Transform opened, and you select entity A with other components opened, when you go back to entity B, Name and Transform will still be opened.