### PR TITLE
Adds drop simple resources inspector

### DIFF
--- a/src/editor/ui/editor_tab.rs
+++ b/src/editor/ui/editor_tab.rs
@@ -15,6 +15,7 @@ pub enum EditorTabName {
     Hierarchy,
     GameView,
     Inspector,
+    Resource,
     ToolBox,
     Settings,
     Other(String),

--- a/src/editor/ui/inspector/mod.rs
+++ b/src/editor/ui/inspector/mod.rs
@@ -1,5 +1,6 @@
 pub mod components_order;
 pub mod refl_impl;
+pub mod resources;
 
 use std::any::TypeId;
 
@@ -22,6 +23,7 @@ use prefab::{component::EntityLink, editor_registry::EditorRegistry};
 use self::{
     components_order::{ComponentsOrder, ComponentsPriority},
     refl_impl::{entity_ref_ui, entity_ref_ui_readonly, many_unimplemented},
+    resources::ResourceTab,
 };
 
 use super::{
@@ -45,6 +47,7 @@ impl Plugin for SpaceInspectorPlugin {
         app.editor_component_priority::<Transform>(1);
 
         app.editor_tab_by_trait(EditorTabName::Inspector, InspectorTab::default());
+        app.editor_tab_by_trait(EditorTabName::Resource, ResourceTab::default());
 
         app.add_systems(Update, execute_inspect_command);
 

--- a/src/editor/ui/inspector/resources.rs
+++ b/src/editor/ui/inspector/resources.rs
@@ -1,0 +1,67 @@
+use bevy::{prelude::*, utils::HashMap};
+
+use bevy_egui::*;
+
+use crate::editor::ui::editor_tab::EditorTab;
+
+#[derive(Resource, Default)]
+pub struct ResourceTab {
+    open_resources: HashMap<String, bool>,
+}
+
+impl EditorTab for ResourceTab {
+    fn ui(&mut self, ui: &mut egui::Ui, _: &mut Commands, world: &mut World) {
+        inspect(ui, world, &mut self.open_resources);
+    }
+
+    fn title(&self) -> egui::WidgetText {
+        "Resource".into()
+    }
+}
+
+pub fn inspect(ui: &mut egui::Ui, world: &mut World, open_resources: &mut HashMap<String, bool>) {
+    let type_registry = world.resource::<AppTypeRegistry>().clone();
+    let type_registry = type_registry.read();
+
+    let mut resources: Vec<_> = type_registry
+        .iter()
+        .filter(|registration| registration.data::<ReflectResource>().is_some())
+        .map(|registration| {
+            (
+                registration
+                    .type_info()
+                    .type_path_table()
+                    .short_path()
+                    .to_string(),
+                registration.type_id(),
+            )
+        })
+        .collect();
+    resources.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
+
+    egui::Grid::new("Resources ID".to_string()).show(ui, |ui| {
+        for (resource_name, type_id) in resources {
+            ui.push_id(format!("{:?}-{}", &type_id, &resource_name), |ui| {
+                let header = egui::CollapsingHeader::new(resource_name.clone())
+                    .default_open(*open_resources.get(&resource_name).unwrap_or(&false))
+                    .show(ui, |ui| {
+                        ui.push_id(format!("content-{:?}-{}", &type_id, &resource_name), |ui| {
+                            bevy_inspector_egui::bevy_inspector::by_type_id::ui_for_resource(
+                                world,
+                                type_id,
+                                ui,
+                                &resource_name,
+                                &type_registry,
+                            );
+                        });
+                    });
+                if header.header_response.clicked() {
+                    let open_name = open_resources.entry(resource_name.clone()).or_default();
+                    //At click header not opened simultaneously so its need to check percent of opened
+                    *open_name = header.openness < 0.5;
+                }
+            });
+            ui.end_row();
+        }
+    });
+}

--- a/src/editor/ui/mod.rs
+++ b/src/editor/ui/mod.rs
@@ -117,7 +117,7 @@ impl Plugin for EditorUiPlugin {
             let [_game, _inspector] = editor.tree.main_surface_mut().split_right(
                 egui_dock::NodeIndex::root(),
                 0.8,
-                vec![EditorTabName::Inspector],
+                vec![EditorTabName::Inspector, EditorTabName::Resource],
             );
             let [_hierarchy, _game] = editor.tree.main_surface_mut().split_left(
                 _game,


### PR DESCRIPTION
Hey, was using the editor for something else today and realized I could not control/manage the bevy resources. This PR attempts to include a drop in simple resources tab using `bevy_inspector_egui::ui_for_resource`. Might be a good MVP for this tab.


![Captura de tela 2023-12-05 144438](https://github.com/rewin123/space_editor/assets/14813660/8963885f-4e33-4c32-aabc-91b0b64bbdee)

![image](https://github.com/rewin123/space_editor/assets/14813660/907fd751-d640-4309-9799-c723d1c7d2ba)
