### PR TITLE
feat: Change the Hierarchy to support `egui::CollapsingHeader`

### DIFF
--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -152,7 +152,15 @@ fn draw_entity(
         .show_header(ui, |ui| {
             ui.selectable_label(is_selected, entity_name)
                 .context_menu(|ui| {
-                    hierarchy_entity_context(ui, commands, entity, changes, clone_events, selected, parent);
+                    hierarchy_entity_context(
+                        ui,
+                        commands,
+                        entity,
+                        changes,
+                        clone_events,
+                        selected,
+                        parent,
+                    );
                 })
         })
         .body(|ui| {
@@ -165,7 +173,15 @@ fn draw_entity(
     } else {
         ui.selectable_label(is_selected, format!("      {}", entity_name))
             .context_menu(|ui| {
-                hierarchy_entity_context(ui, commands, entity, changes, clone_events, selected, parent);
+                hierarchy_entity_context(
+                    ui,
+                    commands,
+                    entity,
+                    changes,
+                    clone_events,
+                    selected,
+                    parent,
+                );
             })
     };
 
@@ -183,7 +199,15 @@ fn draw_entity(
     }
 }
 
-fn hierarchy_entity_context(ui: &mut egui::Ui, commands: &mut Commands<'_, '_>, entity: Entity, changes: &mut EventWriter<'_, NewChange>, clone_events: &mut EventWriter<'_, CloneEvent>, selected: &mut Query<'_, '_, Entity, With<Selected>>, parent: Option<&Parent>) {
+fn hierarchy_entity_context(
+    ui: &mut egui::Ui,
+    commands: &mut Commands<'_, '_>,
+    entity: Entity,
+    changes: &mut EventWriter<'_, NewChange>,
+    clone_events: &mut EventWriter<'_, CloneEvent>,
+    selected: &mut Query<'_, '_, Entity, With<Selected>>,
+    parent: Option<&Parent>,
+) {
     if ui.button("Add child").clicked() {
         let new_id = commands.spawn_empty().insert(PrefabMarker).id();
         commands.entity(entity).add_child(new_id);
@@ -203,10 +227,7 @@ fn hierarchy_entity_context(ui: &mut egui::Ui, commands: &mut Commands<'_, '_>, 
         clone_events.send(CloneEvent { id: entity });
         ui.close_menu();
     }
-    if !selected.is_empty()
-        && !selected.contains(entity)
-        && ui.button("Attach to").clicked()
-    {
+    if !selected.is_empty() && !selected.contains(entity) && ui.button("Attach to").clicked() {
         for e in selected.iter() {
             commands.entity(entity).add_child(e);
         }

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -152,36 +152,7 @@ fn draw_entity(
         .show_header(ui, |ui| {
             ui.selectable_label(is_selected, entity_name)
                 .context_menu(|ui| {
-                    if ui.button("Add child").clicked() {
-                        let new_id = commands.spawn_empty().insert(PrefabMarker).id();
-                        commands.entity(entity).add_child(new_id);
-                        changes.send(NewChange {
-                            change: Arc::new(AddedEntity { entity: new_id }),
-                        });
-                        ui.close_menu();
-                    }
-                    if ui.button("Delete").clicked() {
-                        commands.entity(entity).despawn_recursive();
-                        changes.send(NewChange {
-                            change: Arc::new(RemovedEntity { entity }),
-                        });
-                        ui.close_menu();
-                    }
-                    if ui.button("Clone").clicked() {
-                        clone_events.send(CloneEvent { id: entity });
-                        ui.close_menu();
-                    }
-                    if !selected.is_empty()
-                        && !selected.contains(entity)
-                        && ui.button("Attach to").clicked()
-                    {
-                        for e in selected.iter() {
-                            commands.entity(entity).add_child(e);
-                        }
-                    }
-                    if parent.is_some() && ui.button("Detach").clicked() {
-                        commands.entity(entity).remove_parent();
-                    }
+                    hierarchy_entity_context(ui, commands, entity, changes, clone_events, selected, parent);
                 })
         })
         .body(|ui| {
@@ -194,36 +165,7 @@ fn draw_entity(
     } else {
         ui.selectable_label(is_selected, format!("      {}", entity_name))
             .context_menu(|ui| {
-                if ui.button("Add child").clicked() {
-                    let new_id = commands.spawn_empty().insert(PrefabMarker).id();
-                    commands.entity(entity).add_child(new_id);
-                    changes.send(NewChange {
-                        change: Arc::new(AddedEntity { entity: new_id }),
-                    });
-                    ui.close_menu();
-                }
-                if ui.button("Delete").clicked() {
-                    commands.entity(entity).despawn_recursive();
-                    changes.send(NewChange {
-                        change: Arc::new(RemovedEntity { entity }),
-                    });
-                    ui.close_menu();
-                }
-                if ui.button("Clone").clicked() {
-                    clone_events.send(CloneEvent { id: entity });
-                    ui.close_menu();
-                }
-                if !selected.is_empty()
-                    && !selected.contains(entity)
-                    && ui.button("Attach to").clicked()
-                {
-                    for e in selected.iter() {
-                        commands.entity(entity).add_child(e);
-                    }
-                }
-                if parent.is_some() && ui.button("Detach").clicked() {
-                    commands.entity(entity).remove_parent();
-                }
+                hierarchy_entity_context(ui, commands, entity, changes, clone_events, selected, parent);
             })
     };
 
@@ -238,6 +180,39 @@ fn draw_entity(
         } else {
             commands.entity(entity).remove::<Selected>();
         }
+    }
+}
+
+fn hierarchy_entity_context(ui: &mut egui::Ui, commands: &mut Commands<'_, '_>, entity: Entity, changes: &mut EventWriter<'_, NewChange>, clone_events: &mut EventWriter<'_, CloneEvent>, selected: &mut Query<'_, '_, Entity, With<Selected>>, parent: Option<&Parent>) {
+    if ui.button("Add child").clicked() {
+        let new_id = commands.spawn_empty().insert(PrefabMarker).id();
+        commands.entity(entity).add_child(new_id);
+        changes.send(NewChange {
+            change: Arc::new(AddedEntity { entity: new_id }),
+        });
+        ui.close_menu();
+    }
+    if ui.button("Delete").clicked() {
+        commands.entity(entity).despawn_recursive();
+        changes.send(NewChange {
+            change: Arc::new(RemovedEntity { entity }),
+        });
+        ui.close_menu();
+    }
+    if ui.button("Clone").clicked() {
+        clone_events.send(CloneEvent { id: entity });
+        ui.close_menu();
+    }
+    if !selected.is_empty()
+        && !selected.contains(entity)
+        && ui.button("Attach to").clicked()
+    {
+        for e in selected.iter() {
+            commands.entity(entity).add_child(e);
+        }
+    }
+    if parent.is_some() && ui.button("Detach").clicked() {
+        commands.entity(entity).remove_parent();
     }
 }
 

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -141,7 +141,7 @@ fn draw_entity(
 
     let is_selected = selected.contains(entity);
 
-    let label = if children.is_some_and(|children| children.len() > 1) {
+    let label = if children.is_some() {
         CollapsingState::load_with_default_open(
             ui.ctx(),
             ui.make_persistent_id(entity_name.clone()),
@@ -188,7 +188,7 @@ fn draw_entity(
             }
         })
         .1
-        .response
+        .inner
     } else {
         ui.selectable_label(is_selected, entity_name)
             .context_menu(|ui| {

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -192,7 +192,7 @@ fn draw_entity(
         .1
         .inner
     } else {
-        ui.selectable_label(is_selected, entity_name)
+        ui.selectable_label(is_selected, format!("      {}", entity_name))
             .context_menu(|ui| {
                 if ui.button("Add child").clicked() {
                     let new_id = commands.spawn_empty().insert(PrefabMarker).id();

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use bevy::{prelude::*, utils::HashMap};
-use bevy_egui::{
-    egui::collapsing_header::CollapsingState,
-    *,
-};
+use bevy_egui::{egui::collapsing_header::CollapsingState, *};
 use editor_core::prelude::*;
 use prefab::editor_registry::EditorRegistry;
 use undo::{AddedEntity, NewChange, RemovedEntity, UndoSet};

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -141,7 +141,9 @@ fn draw_entity(
 
     let is_selected = selected.contains(entity);
 
-    let label = if children.is_some() {
+    let label = if children
+        .is_some_and(|children| children.iter().any(|child| query.get(*child).is_ok()))
+    {
         CollapsingState::load_with_default_open(
             ui.ctx(),
             ui.make_persistent_id(entity_name.clone()),

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bevy::{prelude::*, utils::HashMap};
 use bevy_egui::{
-    egui::{collapsing_header::CollapsingState, CollapsingHeader},
+    egui::collapsing_header::CollapsingState,
     *,
 };
 use editor_core::prelude::*;

--- a/crates/editor/src/hierarchy.rs
+++ b/crates/editor/src/hierarchy.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use bevy::{prelude::*, utils::HashMap};
-use bevy_egui::*;
+use bevy_egui::{
+    egui::{collapsing_header::CollapsingState, CollapsingHeader},
+    *,
+};
 use editor_core::prelude::*;
 use prefab::editor_registry::EditorRegistry;
 use undo::{AddedEntity, NewChange, RemovedEntity, UndoSet};
@@ -136,11 +139,58 @@ fn draw_entity(
         |name| format!("{} ({:?})", name.as_str(), entity),
     );
 
-    ui.indent(entity_name.clone(), |ui| {
-        let is_selected = selected.contains(entity);
+    let is_selected = selected.contains(entity);
 
-        let label = ui
-            .selectable_label(is_selected, entity_name)
+    let label = if children.is_some_and(|children| children.len() > 1) {
+        CollapsingState::load_with_default_open(
+            ui.ctx(),
+            ui.make_persistent_id(entity_name.clone()),
+            true,
+        )
+        .show_header(ui, |ui| {
+            ui.selectable_label(is_selected, entity_name)
+                .context_menu(|ui| {
+                    if ui.button("Add child").clicked() {
+                        let new_id = commands.spawn_empty().insert(PrefabMarker).id();
+                        commands.entity(entity).add_child(new_id);
+                        changes.send(NewChange {
+                            change: Arc::new(AddedEntity { entity: new_id }),
+                        });
+                        ui.close_menu();
+                    }
+                    if ui.button("Delete").clicked() {
+                        commands.entity(entity).despawn_recursive();
+                        changes.send(NewChange {
+                            change: Arc::new(RemovedEntity { entity }),
+                        });
+                        ui.close_menu();
+                    }
+                    if ui.button("Clone").clicked() {
+                        clone_events.send(CloneEvent { id: entity });
+                        ui.close_menu();
+                    }
+                    if !selected.is_empty()
+                        && !selected.contains(entity)
+                        && ui.button("Attach to").clicked()
+                    {
+                        for e in selected.iter() {
+                            commands.entity(entity).add_child(e);
+                        }
+                    }
+                    if parent.is_some() && ui.button("Detach").clicked() {
+                        commands.entity(entity).remove_parent();
+                    }
+                })
+        })
+        .body(|ui| {
+            for child in children.unwrap().iter() {
+                draw_entity(commands, ui, query, *child, selected, clone_events, changes);
+            }
+        })
+        .1
+        .response
+    } else {
+        ui.selectable_label(is_selected, entity_name)
             .context_menu(|ui| {
                 if ui.button("Add child").clicked() {
                     let new_id = commands.spawn_empty().insert(PrefabMarker).id();
@@ -172,27 +222,21 @@ fn draw_entity(
                 if parent.is_some() && ui.button("Detach").clicked() {
                     commands.entity(entity).remove_parent();
                 }
-            });
+            })
+    };
 
-        if label.clicked() {
-            if !is_selected {
-                if !ui.input(|i| i.modifiers.shift) {
-                    for e in selected.iter() {
-                        commands.entity(e).remove::<Selected>();
-                    }
+    if label.clicked() {
+        if !is_selected {
+            if !ui.input(|i| i.modifiers.shift) {
+                for e in selected.iter() {
+                    commands.entity(e).remove::<Selected>();
                 }
-                commands.entity(entity).insert(Selected);
-            } else {
-                commands.entity(entity).remove::<Selected>();
             }
+            commands.entity(entity).insert(Selected);
+        } else {
+            commands.entity(entity).remove::<Selected>();
         }
-
-        if let Some(children) = children {
-            for child in children.iter() {
-                draw_entity(commands, ui, query, *child, selected, clone_events, changes);
-            }
-        }
-    });
+    }
 }
 
 #[derive(Component)]


### PR DESCRIPTION
This is a quick change that converts the `selectable_label`s being used for the hierarchy to `CollapsingHeader`s.

There is still an issue with some entities that are brought in from `.glb` files it seems and I would love some feedback about that.

Otherwise I believe that this is just a small feature update.