### PR TITLE
Small camera view tab usability improvement

### DIFF
--- a/crates/editor_ui/src/camera_view.rs
+++ b/crates/editor_ui/src/camera_view.rs
@@ -6,8 +6,9 @@ use bevy::{
     },
     window::{PrimaryWindow, WindowRef},
 };
-use bevy_egui::egui::{self};
+use bevy_egui::egui::{self, Color32};
 
+use space_prefab::component::CameraPlay;
 use space_shared::*;
 
 use crate::{prelude::EditorTabName, DisableCameraSkip, EditorUiAppExt};
@@ -70,20 +71,36 @@ impl EditorTab for CameraViewTab {
             Without<ViewCamera>,
         )>();
 
-        egui::ComboBox::from_label("Camera")
-            .selected_text(format!("{:?}", self.camera_entity))
-            .show_ui(ui, |ui| {
-                for entity in camera_query.iter(world) {
-                    ui.selectable_value(
-                        &mut self.camera_entity,
-                        Some(entity),
-                        format!("{:?}", entity),
-                    );
-                }
-            });
+        if camera_query.iter(world).count() > 0 {
+            egui::ComboBox::from_label("Camera")
+                .selected_text(format!("{:?}", self.camera_entity))
+                .show_ui(ui, |ui| {
+                    for entity in camera_query.iter(world) {
+                        ui.selectable_value(
+                            &mut self.camera_entity,
+                            Some(entity),
+                            format!("{:?}", entity),
+                        );
+                    }
+                });
+            ui.add_space(4.);
+            ui.separator();
+        } else {
+            ui.label(egui::RichText::new("No available Cameras").color(Color32::LIGHT_RED));
 
-        ui.add_space(4.);
-        ui.separator();
+            ui.add_space(4.);
+            ui.separator();
+            ui.add_space(4.);
+            if ui.button("Add Playmode Camera").clicked() {
+                commands.spawn((
+                    Camera3d::default(),
+                    Name::new("Camera3d".to_string()),
+                    Transform::default(),
+                    Visibility::default(),
+                    CameraPlay::default(),
+                ));
+            }
+        }
 
         // Moves camera below the selection
         let pos = ui.next_widget_position();


### PR DESCRIPTION
If no camera is available, displays no camera message and add playmode camera button

<img width="280" alt="Captura de Tela 2023-12-29 às 2 46 48 PM" src="https://github.com/rewin123/space_editor/assets/14813660/192ba458-0cb2-449c-b691-2a31dc1c809c">
<img width="254" alt="Captura de Tela 2023-12-29 às 2 46 56 PM" src="https://github.com/rewin123/space_editor/assets/14813660/ce0c99c2-2a37-4f2d-93b8-abb23dceb54d">
