### PR TITLE
Orders Button/Selectable lists by Name

### DIFF
--- a/crates/editor_ui/src/bottom_menu.rs
+++ b/crates/editor_ui/src/bottom_menu.rs
@@ -4,22 +4,19 @@ use space_editor_core::prelude::*;
 use space_prefab::plugins::PrefabPlugin;
 use space_shared::{ext::egui_file, *};
 
-/// Plugin to activate bot menu in editor UI
-pub struct BotMenuPlugin;
+/// Plugin to activate bottom menu in editor UI
+pub struct BottomMenuPlugin;
 
-impl Plugin for BotMenuPlugin {
+impl Plugin for BottomMenuPlugin {
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<PrefabPlugin>() {
             app.add_plugins(PrefabPlugin);
         }
         app.init_resource::<EditorLoader>();
-        app.init_resource::<BotMenuState>();
+        app.init_resource::<BottomMenuState>();
 
-        app.add_systems(
-            Update,
-            bot_menu.before(EditorLoadSet).in_set(EditorSet::Editor),
-        );
-        app.add_systems(Update, bot_menu_game.in_set(EditorSet::Game));
+        app.add_systems(Update, menu.before(EditorLoadSet).in_set(EditorSet::Editor));
+        app.add_systems(Update, in_game_menu.in_set(EditorSet::Game));
         app.add_event::<MenuLoadEvent>();
     }
 }
@@ -29,7 +26,7 @@ pub struct MenuLoadEvent {
     pub path: String,
 }
 
-fn bot_menu_game(
+fn in_game_menu(
     mut smoothed_dt: Local<f32>,
     mut ctxs: EguiContexts,
     mut state: ResMut<NextState<EditorState>>,
@@ -48,17 +45,17 @@ fn bot_menu_game(
 }
 
 #[derive(Resource, Default)]
-pub struct BotMenuState {
+pub struct BottomMenuState {
     pub file_dialog: Option<egui_file::FileDialog>,
     pub gltf_dialog: Option<egui_file::FileDialog>,
     pub path: String,
 }
 
-pub fn bot_menu(
+pub fn menu(
     mut ctxs: EguiContexts,
     _state: ResMut<NextState<EditorState>>,
     mut events: EventReader<MenuLoadEvent>,
-    mut menu_state: ResMut<BotMenuState>,
+    mut menu_state: ResMut<BottomMenuState>,
     mut editor_events: EventWriter<EditorEvent>,
     background_tasks: Res<BackgroundTaskStorage>,
 ) {

--- a/crates/editor_ui/src/editor_tab.rs
+++ b/crates/editor_ui/src/editor_tab.rs
@@ -10,7 +10,7 @@ pub trait EditorTab {
     fn title(&self) -> egui::WidgetText;
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum EditorTabName {
     Hierarchy,
     GameView,
@@ -102,25 +102,29 @@ impl<'a, 'w, 's> egui_dock::TabViewer for EditorTabViewer<'a, 'w, 's> {
         surface: egui_dock::SurfaceIndex,
         node: egui_dock::NodeIndex,
     ) {
-        ui.set_min_width(120.0);
+        ui.set_min_width(200.0);
         ui.style_mut().visuals.button_frame = false;
         let mut counter = 0;
-        for reg in self.registry.iter() {
-            if !self.visible.contains(reg.0) {
+        let mut tab_registry: Vec<(&EditorTabName, &EditorUiReg)> = self.registry.iter().collect();
+        tab_registry.sort_by(|a, b| a.0.cmp(b.0));
+
+        for registry in tab_registry.iter() {
+            if !self.visible.contains(registry.0) {
                 let format_name;
-                if let EditorTabName::Other(name) = reg.0 {
+                if let EditorTabName::Other(name) = registry.0 {
                     format_name = name.clone();
                 } else {
-                    format_name = format!("{:?}", reg.0);
+                    format_name = format!("{:?}", registry.0);
                 }
 
                 if ui.button(format_name).clicked() {
                     self.tab_commands.push(EditorTabCommand::Add {
-                        name: reg.0.clone(),
+                        name: registry.0.clone(),
                         surface,
                         node,
                     });
                 }
+                ui.spacing();
                 counter += 1;
             }
         }

--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -100,7 +100,7 @@ pub fn show_hierarchy(
             ui.menu_button(category_name, |ui| {
                 let mut categories_vec: Vec<(&String, &EditorBundleUntyped)> =
                     category_bundle.iter().collect();
-                categories_vec.sort_by(|a, b| a.0.cmp(&b.0));
+                categories_vec.sort_by(|a, b| a.0.cmp(b.0));
 
                 for (name, dyn_bundle) in categories_vec {
                     if ui.button(name).clicked() {

--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -6,7 +6,7 @@ use space_editor_core::prelude::*;
 use space_prefab::editor_registry::EditorRegistry;
 use space_undo::{AddedEntity, NewChange, RemovedEntity, UndoSet};
 
-use crate::ui_registration::BundleReg;
+use crate::ui_registration::{BundleReg, EditorBundleUntyped};
 use space_shared::*;
 
 use super::{editor_tab::EditorTabName, EditorUiAppExt, EditorUiRef};
@@ -96,9 +96,13 @@ pub fn show_hierarchy(
         });
 
         ui.label("Spawnable bundles");
-        for (cat_name, cat) in ui_reg.bundles.iter() {
-            ui.menu_button(cat_name, |ui| {
-                for (name, dyn_bundle) in cat {
+        for (category_name, category_bundle) in ui_reg.bundles.iter() {
+            ui.menu_button(category_name, |ui| {
+                let mut categories_vec: Vec<(&String, &EditorBundleUntyped)> =
+                    category_bundle.iter().collect();
+                categories_vec.sort_by(|a, b| a.0.cmp(&b.0));
+
+                for (name, dyn_bundle) in categories_vec {
                     if ui.button(name).clicked() {
                         let entity = dyn_bundle.spawn(&mut commands);
                         changes.send(NewChange {

--- a/crates/editor_ui/src/lib.rs
+++ b/crates/editor_ui/src/lib.rs
@@ -7,7 +7,7 @@ mod mouse_check;
 pub mod asset_inspector;
 
 /// This module contains logic for bottom menu
-pub mod bot_menu;
+pub mod bottom_menu;
 
 /// This module contains UI logic for undo/redo functionality
 pub mod change_chain;
@@ -88,7 +88,7 @@ use self::{
 
 pub mod prelude {
     pub use super::{
-        asset_inspector::*, bot_menu::*, change_chain::*, debug_panels::*, editor_tab::*,
+        asset_inspector::*, bottom_menu::*, change_chain::*, debug_panels::*, editor_tab::*,
         game_view::*, hierarchy::*, inspector::*, settings::*, tool::*, tools::*,
         ui_registration::*,
     };
@@ -668,7 +668,7 @@ impl Plugin for EditorUiPlugin {
             app.add_plugins(SelectedPlugin);
         }
 
-        app.add_plugins((bot_menu::BotMenuPlugin, MouseCheck));
+        app.add_plugins((bottom_menu::BottomMenuPlugin, MouseCheck));
 
         app.configure_sets(
             Update,
@@ -684,7 +684,7 @@ impl Plugin for EditorUiPlugin {
                 show_editor_ui
                     .before(update_pan_orbit)
                     .before(ui_camera_block)
-                    .after(bot_menu::bot_menu),
+                    .after(bottom_menu::menu),
                 set_camera_viewport,
             )
                 .in_set(UiSystemSet),

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,11 +86,11 @@ The dock system in the Editor UI offers a high degree of flexibility:
 
 - For added convenience, tabs can also be detached from the main dock system and placed in subwindows, allowing you to arrange your workspace exactly the way you prefer.
 
-## Bot menu
+## Bottom menu
 
 ![bot_menu.png](https://github.com/rewin123/space_editor/blob/main/docs/imgs/bot_menu.png)
 
-Bot menu is panel with settings for current scene. It contains:
+Bottom menu is panel with settings for current scene. It contains:
 
 - Path to prefab without "scn.ron" extension
 - Folder button to open file dialog to select prefab


### PR DESCRIPTION
And some style changes

Order of new tab popup window is preserved as defined in Enum (+ increased spacing between elements)
<img width="276" alt="Captura de Tela 2023-12-29 às 8 17 04 PM" src="https://github.com/rewin123/space_editor/assets/14813660/f7a9da28-7439-490b-b2e6-841c1c188442">

Mesh (and other bundles) have alphabetical order

<img width="272" alt="Captura de Tela 2023-12-29 às 8 17 10 PM" src="https://github.com/rewin123/space_editor/assets/14813660/07b4a128-2643-408b-ada9-09f89a0ad57d">


* Renamed bot_menu to bottom_menu