### PR TITLE
Support sending events through UI

### DIFF
--- a/crates/editor_ui/src/editor_tab.rs
+++ b/crates/editor_ui/src/editor_tab.rs
@@ -18,11 +18,11 @@ pub enum EditorTabName {
     GameView,
     Hierarchy,
     Inspector,
-    Other(String),
     Resource,
     RuntimeAssets,
     Settings,
     ToolBox,
+    Other(String),
 }
 
 pub type EditorTabShowFn = Box<dyn Fn(&mut egui::Ui, &mut Commands, &mut World) + Send + Sync>;

--- a/crates/editor_ui/src/editor_tab.rs
+++ b/crates/editor_ui/src/editor_tab.rs
@@ -14,15 +14,15 @@ pub trait EditorTab {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum EditorTabName {
     CameraView,
+    Event,
     GameView,
     Hierarchy,
     Inspector,
+    Other(String),
     Resource,
-    Event,
     RuntimeAssets,
     Settings,
     ToolBox,
-    Other(String),
 }
 
 pub type EditorTabShowFn = Box<dyn Fn(&mut egui::Ui, &mut Commands, &mut World) + Send + Sync>;

--- a/crates/editor_ui/src/editor_tab.rs
+++ b/crates/editor_ui/src/editor_tab.rs
@@ -18,6 +18,7 @@ pub enum EditorTabName {
     Hierarchy,
     Inspector,
     Resource,
+    Event,
     RuntimeAssets,
     Settings,
     ToolBox,

--- a/crates/editor_ui/src/editor_tab.rs
+++ b/crates/editor_ui/src/editor_tab.rs
@@ -14,7 +14,7 @@ pub trait EditorTab {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum EditorTabName {
     CameraView,
-    Event,
+    EventDebugger,
     GameView,
     Hierarchy,
     Inspector,

--- a/crates/editor_ui/src/inspector/events.rs
+++ b/crates/editor_ui/src/inspector/events.rs
@@ -1,0 +1,40 @@
+use bevy::prelude::*;
+
+use bevy_egui::*;
+
+use crate::prelude::*;
+
+#[derive(Resource, Default)]
+pub struct EventTab;
+
+impl EditorTab for EventTab {
+    fn ui(&mut self, ui: &mut egui::Ui, _: &mut Commands, world: &mut World) {
+        inspect(ui, world);
+    }
+
+    fn title(&self) -> egui::WidgetText {
+        "Event".into()
+    }
+}
+
+pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
+    let mut events = world
+        .resource::<EditorRegistry>()
+        .send_events
+        .iter()
+        .map(|(type_id, event)| (*type_id, event.clone()))
+        .collect::<Vec<_>>();
+
+    events.sort_by(|(_, a), (_, b)| a.name().cmp(b.name()));
+
+    egui::Grid::new("Events ID".to_string()).show(ui, move |ui| {
+        for (type_id, event) in events.into_iter() {
+            ui.push_id(format!("{:?}-{}", &type_id, event.name()), |ui| {
+                if ui.button(event.name()).clicked() {
+                    event.send(world);
+                }
+            });
+            ui.end_row();
+        }
+    });
+}

--- a/crates/editor_ui/src/inspector/events.rs
+++ b/crates/editor_ui/src/inspector/events.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_egui::*;
+use bevy_egui::{egui::Color32, *};
 
 use crate::prelude::*;
 
@@ -20,18 +20,22 @@ impl EditorTab for EventDebuggerTab {
 pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
     let events = &world.resource::<EditorRegistry>().send_events.clone();
 
-    egui::Grid::new("Events ID".to_string()).show(ui, move |ui| {
-        for event in events {
-            ui.push_id(event.path(), |ui| {
-                let clicked = ui
-                    .button(event.name())
-                    .on_hover_text(event.path())
-                    .clicked();
-                if clicked {
-                    event.send(world);
-                };
-            });
-            ui.end_row();
-        }
-    });
+    if events.is_empty() {
+        ui.label(egui::RichText::new("No events registered").color(Color32::LIGHT_RED));
+    } else {
+        egui::Grid::new("Events ID".to_string()).show(ui, move |ui| {
+            for event in events {
+                ui.push_id(event.path(), |ui| {
+                    let clicked = ui
+                        .button(event.name())
+                        .on_hover_text(event.path())
+                        .clicked();
+                    if clicked {
+                        event.send(world);
+                    };
+                });
+                ui.end_row();
+            }
+        });
+    }
 }

--- a/crates/editor_ui/src/inspector/events.rs
+++ b/crates/editor_ui/src/inspector/events.rs
@@ -5,15 +5,15 @@ use bevy_egui::*;
 use crate::prelude::*;
 
 #[derive(Resource, Default)]
-pub struct EventTab;
+pub struct EventDebuggerTab;
 
-impl EditorTab for EventTab {
+impl EditorTab for EventDebuggerTab {
     fn ui(&mut self, ui: &mut egui::Ui, _: &mut Commands, world: &mut World) {
         inspect(ui, world);
     }
 
     fn title(&self) -> egui::WidgetText {
-        "Event".into()
+        "Event Debugger".into()
     }
 }
 

--- a/crates/editor_ui/src/inspector/events.rs
+++ b/crates/editor_ui/src/inspector/events.rs
@@ -29,10 +29,14 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
 
     egui::Grid::new("Events ID".to_string()).show(ui, move |ui| {
         for (type_id, event) in events.into_iter() {
-            ui.push_id(format!("{:?}-{}", &type_id, event.name()), |ui| {
-                if ui.button(event.name()).clicked() {
+            ui.push_id(format!("{:?}-{}", &type_id, event.path()), |ui| {
+                let clicked = ui
+                    .button(event.name())
+                    .on_hover_text(event.path())
+                    .clicked();
+                if clicked {
                     event.send(world);
-                }
+                };
             });
             ui.end_row();
         }

--- a/crates/editor_ui/src/inspector/events.rs
+++ b/crates/editor_ui/src/inspector/events.rs
@@ -18,18 +18,11 @@ impl EditorTab for EventTab {
 }
 
 pub fn inspect(ui: &mut egui::Ui, world: &mut World) {
-    let mut events = world
-        .resource::<EditorRegistry>()
-        .send_events
-        .iter()
-        .map(|(type_id, event)| (*type_id, event.clone()))
-        .collect::<Vec<_>>();
-
-    events.sort_by(|(_, a), (_, b)| a.name().cmp(b.name()));
+    let events = &world.resource::<EditorRegistry>().send_events.clone();
 
     egui::Grid::new("Events ID".to_string()).show(ui, move |ui| {
-        for (type_id, event) in events.into_iter() {
-            ui.push_id(format!("{:?}-{}", &type_id, event.path()), |ui| {
+        for event in events {
+            ui.push_id(event.path(), |ui| {
                 let clicked = ui
                     .button(event.name())
                     .on_hover_text(event.path())

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -52,7 +52,7 @@ impl Plugin for SpaceInspectorPlugin {
 
         app.editor_tab_by_trait(EditorTabName::Inspector, InspectorTab::default());
         app.editor_tab_by_trait(EditorTabName::Resource, ResourceTab::default());
-        app.editor_tab_by_trait(EditorTabName::Event, EventTab::default());
+        app.editor_tab_by_trait(EditorTabName::Event, EventTab);
         app.editor_tab_by_trait(EditorTabName::RuntimeAssets, RuntimeAssetsTab::default());
 
         app.add_systems(Update, execute_inspect_command);

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -1,4 +1,5 @@
 pub mod components_order;
+pub mod events;
 pub mod refl_impl;
 pub mod resources;
 pub mod runtime_assets;
@@ -23,6 +24,7 @@ use space_shared::ext::bevy_inspector_egui::{
 
 use self::{
     components_order::{ComponentsOrder, ComponentsPriority},
+    events::EventTab,
     refl_impl::{entity_ref_ui, entity_ref_ui_readonly, many_unimplemented},
     resources::ResourceTab,
     runtime_assets::RuntimeAssetsTab,
@@ -50,6 +52,7 @@ impl Plugin for SpaceInspectorPlugin {
 
         app.editor_tab_by_trait(EditorTabName::Inspector, InspectorTab::default());
         app.editor_tab_by_trait(EditorTabName::Resource, ResourceTab::default());
+        app.editor_tab_by_trait(EditorTabName::Event, EventTab::default());
         app.editor_tab_by_trait(EditorTabName::RuntimeAssets, RuntimeAssetsTab::default());
 
         app.add_systems(Update, execute_inspect_command);

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -24,7 +24,7 @@ use space_shared::ext::bevy_inspector_egui::{
 
 use self::{
     components_order::{ComponentsOrder, ComponentsPriority},
-    events::EventTab,
+    events::EventDebuggerTab,
     refl_impl::{entity_ref_ui, entity_ref_ui_readonly, many_unimplemented},
     resources::ResourceTab,
     runtime_assets::RuntimeAssetsTab,
@@ -52,7 +52,7 @@ impl Plugin for SpaceInspectorPlugin {
 
         app.editor_tab_by_trait(EditorTabName::Inspector, InspectorTab::default());
         app.editor_tab_by_trait(EditorTabName::Resource, ResourceTab::default());
-        app.editor_tab_by_trait(EditorTabName::Event, EventTab);
+        app.editor_tab_by_trait(EditorTabName::EventDebugger, EventDebuggerTab);
         app.editor_tab_by_trait(EditorTabName::RuntimeAssets, RuntimeAssetsTab::default());
 
         app.add_systems(Update, execute_inspect_command);

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -85,6 +85,33 @@ impl AddDefaultComponent {
     }
 }
 
+/// Container struct for function to send default event
+#[derive(Clone)]
+pub struct SendEvent {
+    name: String,
+    func: Arc<dyn Fn(&mut World) + Send + Sync>,
+}
+
+impl SendEvent {
+    pub fn new<T: Default + Event>() -> Self {
+        let name = std::any::type_name::<T>().into();
+        Self {
+            name,
+            func: Arc::new(move |world| {
+                world.send_event(T::default());
+            }),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn send(&self, world: &mut World) {
+        (self.func)(world);
+    }
+}
+
 /// Resource, which contains all custom editor registry
 #[derive(Default, Resource, Clone)]
 pub struct EditorRegistry {
@@ -92,6 +119,7 @@ pub struct EditorRegistry {
     pub spawn_components: HashMap<TypeId, AddDefaultComponent>,
     pub clone_components: Vec<CloneComponent>,
     pub remove_components: HashMap<TypeId, RemoveComponent>,
+    pub send_events: HashMap<TypeId, SendEvent>,
     pub silent: HashSet<TypeId>, //skip in inspector ui
 }
 
@@ -160,6 +188,12 @@ impl EditorRegistry {
             (t.func)(cmds, src);
         }
     }
+
+    /// Register new event, which will be shown in editor UI and can be sent
+    pub fn event_register<T: Event + Default>(&mut self) {
+        let id = TypeId::of::<T>();
+        self.send_events.insert(id, SendEvent::new::<T>());
+    }
 }
 
 pub trait EditorRegistryExt {
@@ -205,6 +239,9 @@ pub trait EditorRegistryExt {
             + 'static
             + GetTypeRegistration
             + TypePath;
+
+    /// register new event in editor UI
+    fn editor_event<T: Event + Default>(&mut self) -> &mut Self;
 }
 
 impl EditorRegistryExt for App {
@@ -283,6 +320,13 @@ impl EditorRegistryExt for App {
     {
         self.add_systems(Update, into_sync_system::<T, Target>);
 
+        self
+    }
+
+    fn editor_event<T: Event + Default>(&mut self) -> &mut Self {
+        self.world
+            .resource_mut::<EditorRegistry>()
+            .event_register::<T>();
         self
     }
 }

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -126,7 +126,7 @@ pub struct EditorRegistry {
     pub spawn_components: HashMap<TypeId, AddDefaultComponent>,
     pub clone_components: Vec<CloneComponent>,
     pub remove_components: HashMap<TypeId, RemoveComponent>,
-    pub send_events: HashMap<TypeId, SendEvent>,
+    pub send_events: Vec<SendEvent>,
     pub silent: HashSet<TypeId>, //skip in inspector ui
 }
 
@@ -198,8 +198,10 @@ impl EditorRegistry {
 
     /// Register new event, which will be shown in editor UI and can be sent
     pub fn event_register<T: Event + Default>(&mut self) {
-        let id = TypeId::of::<T>();
-        self.send_events.insert(id, SendEvent::new::<T>());
+        self.send_events.push(SendEvent::new::<T>());
+        self.send_events.sort_unstable_by_key(|send_event| {
+            (send_event.name().to_owned(), send_event.path().to_owned())
+        });
     }
 }
 

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -241,7 +241,7 @@ pub trait EditorRegistryExt {
             + TypePath;
 
     /// register new event in editor UI
-    fn editor_event<T: Event + Default>(&mut self) -> &mut Self;
+    fn editor_registry_event<T: Event + Default>(&mut self) -> &mut Self;
 }
 
 impl EditorRegistryExt for App {
@@ -323,7 +323,7 @@ impl EditorRegistryExt for App {
         self
     }
 
-    fn editor_event<T: Event + Default>(&mut self) -> &mut Self {
+    fn editor_registry_event<T: Event + Default>(&mut self) -> &mut Self {
         self.world
             .resource_mut::<EditorRegistry>()
             .event_register::<T>();

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -89,14 +89,17 @@ impl AddDefaultComponent {
 #[derive(Clone)]
 pub struct SendEvent {
     name: String,
+    path: String,
     func: Arc<dyn Fn(&mut World) + Send + Sync>,
 }
 
 impl SendEvent {
     pub fn new<T: Default + Event>() -> Self {
-        let name = std::any::type_name::<T>().into();
+        let path = std::any::type_name::<T>().to_string();
+        let name = path.split("::").last().unwrap_or("UnnamedEvent").into();
         Self {
             name,
+            path,
             func: Arc::new(move |world| {
                 world.send_event(T::default());
             }),
@@ -105,6 +108,10 @@ impl SendEvent {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     pub fn send(&self, world: &mut World) {

--- a/crates/prefab/src/load.rs
+++ b/crates/prefab/src/load.rs
@@ -80,8 +80,7 @@ fn load_prefab(
         Changed<PrefabLoader>,
     >,
     auto_childs: Query<Entity, With<PrefabAutoChild>>,
-    assets: ResMut<AssetServer>,
-    state: Res<State<EditorState>>,
+    assets: ResMut<AssetServer>
 ) {
     for (e, l, children, tr, vis) in query.iter() {
         if tr.is_none() {

--- a/crates/prefab/src/load.rs
+++ b/crates/prefab/src/load.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_scene_hook::SceneHook;
-use space_shared::{EditorState, PrefabMarker};
+use space_shared::PrefabMarker;
 
 use crate::prelude::EditorRegistryExt;
 
@@ -80,7 +80,7 @@ fn load_prefab(
         Changed<PrefabLoader>,
     >,
     auto_childs: Query<Entity, With<PrefabAutoChild>>,
-    assets: ResMut<AssetServer>
+    assets: ResMut<AssetServer>,
 ) {
     for (e, l, children, tr, vis) in query.iter() {
         if tr.is_none() {

--- a/crates/prefab/src/load.rs
+++ b/crates/prefab/src/load.rs
@@ -102,8 +102,6 @@ fn load_prefab(
             commands.entity(e).clear_children();
         }
 
-        let is_editor = *state.get() == EditorState::Editor;
-
         let scene: Handle<DynamicScene> = assets.load(&l.path);
 
         let id = commands

--- a/examples/event_example.rs
+++ b/examples/event_example.rs
@@ -27,7 +27,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((PrefabBundle::new("cube.scn.ron"), Spin(false)));
+    commands.spawn((PrefabBundle::new("cube.scn.ron"), Spin(false), PrefabMarker));
 }
 
 fn spin_entities(mut query: Query<(&mut Transform, &Spin)>, time: Res<Time>) {

--- a/examples/event_example.rs
+++ b/examples/event_example.rs
@@ -18,7 +18,7 @@ fn main() {
         .add_plugins(SpaceEditorPlugin)
         .add_systems(Startup, simple_editor_setup)
         .add_event::<ToggleSpin>()
-        .editor_event::<ToggleSpin>()
+        .editor_registry_event::<ToggleSpin>()
         .editor_registry::<Spin>()
         .add_systems(Startup, setup)
         .add_systems(Update, spin_entities)

--- a/examples/event_example.rs
+++ b/examples/event_example.rs
@@ -39,8 +39,8 @@ fn spin_entities(mut query: Query<(&mut Transform, &Spin)>, time: Res<Time>) {
 }
 
 fn handle_spin_event(mut query: Query<&mut Spin>, mut events: EventReader<ToggleSpin>) {
-    for mut spin in query.iter_mut() {
-        for _ in events.read() {
+    for _ in events.read() {
+        for mut spin in query.iter_mut() {
             spin.0 = !spin.0;
         }
     }

--- a/examples/event_example.rs
+++ b/examples/event_example.rs
@@ -4,7 +4,6 @@
 
 use bevy::prelude::*;
 use space_editor::prelude::*;
-use space_prefab::ext::shape::Cube;
 
 #[derive(Event, Default)]
 pub struct ToggleSpin;
@@ -27,20 +26,8 @@ fn main() {
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
-    commands.spawn((
-        Spin(false),
-        PbrBundle {
-            mesh: meshes.add(Mesh::from(Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
-    ));
+fn setup(mut commands: Commands) {
+    commands.spawn((PrefabBundle::new("cube.scn.ron"), Spin(false)));
 }
 
 fn spin_entities(mut query: Query<(&mut Transform, &Spin)>, time: Res<Time>) {

--- a/examples/event_example.rs
+++ b/examples/event_example.rs
@@ -1,0 +1,60 @@
+// Simple event example
+// Run command:
+// cargo run --example event_example
+
+use bevy::prelude::*;
+use space_editor::prelude::*;
+use space_prefab::ext::shape::Cube;
+
+#[derive(Event, Default)]
+pub struct ToggleSpin;
+
+#[derive(Component, Default, Reflect, Clone)]
+#[reflect(Component, Default)]
+pub struct Spin(bool);
+
+fn main() {
+    App::default()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(SpaceEditorPlugin)
+        .add_systems(Startup, simple_editor_setup)
+        .add_event::<ToggleSpin>()
+        .editor_event::<ToggleSpin>()
+        .editor_registry::<Spin>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, spin_entities)
+        .add_systems(Update, handle_spin_event)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Spin(false),
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            ..default()
+        },
+    ));
+}
+
+fn spin_entities(mut query: Query<(&mut Transform, &Spin)>, time: Res<Time>) {
+    for (mut transform, spin) in query.iter_mut() {
+        if spin.0 {
+            transform.rotate(Quat::from_rotation_y(time.delta_seconds()));
+        }
+    }
+}
+
+fn handle_spin_event(mut query: Query<&mut Spin>, mut events: EventReader<ToggleSpin>) {
+    for mut spin in query.iter_mut() {
+        for _ in events.read() {
+            spin.0 = !spin.0;
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new tab enabling the user to send events through the UI:

https://github.com/rewin123/space_editor/assets/3222456/aa1cfc51-cd13-4cd4-b931-55e1cdcefcf3

Events must be registered using `App.editor_registry_event()`, similar to `App.editor_registry()` for components. An example is provided in `/examples/event_example.rs`.

Currently events must implement Default, but a future goal is allowing the user to modify the event in the UI before sending it.