### PR TITLE
Fixed File browser for browsing `assets/`

### DIFF
--- a/crates/editor_ui/src/bottom_menu.rs
+++ b/crates/editor_ui/src/bottom_menu.rs
@@ -93,12 +93,8 @@ pub fn menu(
                     }
                 } else {
                     let mut need_move_to_default_dir = false;
-                    if let Some(path) = dialog.path() {
-                        if let Some(path) = path.to_str() {
-                            if !path.contains("assets") {
-                                need_move_to_default_dir = true;
-                            }
-                        } else {
+                    if let Some(path) = dialog.directory().to_str() {
+                        if !path.contains("assets") {
                             need_move_to_default_dir = true;
                         }
                     } else {
@@ -123,12 +119,8 @@ pub fn menu(
                     }
                 } else {
                     let mut need_move_to_default_dir = false;
-                    if let Some(path) = gltf_dialog.path() {
-                        if let Some(path) = path.to_str() {
-                            if !path.contains("assets") {
-                                need_move_to_default_dir = true;
-                            }
-                        } else {
+                    if let Some(path) = gltf_dialog.directory().to_str() {
+                        if !path.contains("assets") {
                             need_move_to_default_dir = true;
                         }
                     } else {

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -19,4 +19,4 @@ bevy-inspector-egui = { version = "0.22", features = [
     "bevy_pbr",
     "highlight_changes",
 ] }
-egui_file = "0.13"
+egui_file = { git = "https://github.com/Barugon/egui_file.git" }


### PR DESCRIPTION
Addresses #148.

Currently relies on the git repo for [`egui_file`](https://github.com/Barugon/egui_file) until there is a new release that will have the required change on crates.io.