### PR TITLE
Adds support for UI in custom events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ opt-level = 3
 [features]
 bevy_xpbd_3d = ["dep:space_bevy_xpbd_plugin"]
 persistence_editor = []
+no_event_registration = ["space_prefab/no_event_registration"]
 editor = []
 default = ["bevy_xpbd_3d", "persistence_editor", "editor"]
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Aspires to be editor for bevy while there is no official editor.
 - **Prefab Reusability**: Prefabs can be nested within other prefabs, improving reusability and organization in your projects. 
 - **Many custom components**: Space Editor implements various custom components to seamlessly integrate its saving system with the standard Bevy scene format. 
 - **Easy API for customization**: Customize or register your own components within the editor with ease, tailoring it to your specific project needs.
-- **Event debugging**: Send events directly from the editor UI for easier gameplay debugging.  
+- **Event dispatching**: Send custom events directly from the editor UI for easier gameplay debugging.  
 - **API for adding tabs**: Extend the functionality of the editor by easily adding new tabs, enhancing your workflow. 
 
 Getting Started
@@ -95,15 +95,25 @@ The representation of components in the editor UI can also be customized by bevy
 
 ### Events
 
-Events can be added to the editor gui with the following:
+Custom Events can be added to the editor UI with the following:
 
 ```rs
+#[derive(Event, Default, Resource, Reflect, Clone)]
+#[reflect(Resource)]
+pub struct Name;
+
 use editor::prelude::EditorRegistryExt;
 
 app.editor_registry_event::<Name>();
 ```
 
-One limitation is that events must implement `Default`. Once registered, events can be sent using the `Event Debugger` tab. 
+One limitation is that events must implement `Event, Default, Resource, Reflect, Clone`, with `Resource` reflected. Once registered, events can be sent using the `Event Dispatcher` tab.
+
+> Obs: editor already handles internally objects registration and initialization:
+> 
+> `register_type::<T>() and init_resource::<T>()`
+
+> To disable this, use feature `no_event_registration`.
 
 ### Prefab
 A prefab is simply a Bevy scene serialized to a readable and editable RON format. However, it needs to be spawned through PrefabBundle to activate custom logic such as adding global transforms to an object.

--- a/crates/editor_ui/src/inspector/events_dispatcher.rs
+++ b/crates/editor_ui/src/inspector/events_dispatcher.rs
@@ -47,7 +47,7 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World, open_events: &mut HashMap<S
                                 );
 
                                 let clicked = ui
-                                    .button(event.name())
+                                    .button(format!("Send {}", event.name()))
                                     .on_hover_text(event.path())
                                     .clicked();
                                 if clicked {

--- a/crates/editor_ui/src/ui_registration.rs
+++ b/crates/editor_ui/src/ui_registration.rs
@@ -1,4 +1,6 @@
-use bevy::{ecs::system::EntityCommands, utils::HashMap};
+use std::collections::BTreeMap;
+
+use bevy::ecs::system::EntityCommands;
 
 use space_prefab::{component::*, ext::*};
 use space_shared::PrefabMarker;
@@ -8,7 +10,7 @@ pub const MESH_CATEGORY: &str = "mesh";
 /// Resource with bundles to spawn
 #[derive(Resource, Default)]
 pub struct BundleReg {
-    pub bundles: HashMap<String, HashMap<String, EditorBundleUntyped>>,
+    pub bundles: BTreeMap<String, BTreeMap<String, EditorBundleUntyped>>,
 }
 
 impl BundleReg {

--- a/crates/prefab/Cargo.toml
+++ b/crates/prefab/Cargo.toml
@@ -10,6 +10,9 @@ description = "Subcrate for the space_editor crate. Contains the prefab systems 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+no_event_registration = []
+
 [dependencies]
 bevy.workspace = true
 ron.workspace = true

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -95,7 +95,7 @@ pub struct SendEvent {
 }
 
 impl SendEvent {
-    pub fn new<T: Default + Event + Resource>() -> Self {
+    pub fn new<T: Default + Event + Resource + Clone>() -> Self {
         let path = std::any::type_name::<T>().to_string();
         let name = path.split("::").last().unwrap_or("UnnamedEvent").into();
         let type_id = TypeId::of::<T>();
@@ -104,7 +104,8 @@ impl SendEvent {
             path,
             type_id,
             func: Arc::new(move |world| {
-                world.send_event(T::default());
+                let event = world.resource::<T>().clone();
+                world.send_event(event);
             }),
         }
     }
@@ -201,7 +202,7 @@ impl EditorRegistry {
 
     /// Register new event, which will be shown in editor UI and can be sent
     pub fn event_register<
-        T: Event + Default + Resource + Reflect + Send + 'static + GetTypeRegistration,
+        T: Event + Default + Resource + Reflect + Send + Clone + 'static + GetTypeRegistration,
     >(
         &mut self,
     ) {
@@ -258,7 +259,7 @@ pub trait EditorRegistryExt {
 
     /// register new event in editor UI
     fn editor_registry_event<
-        T: Event + Default + Resource + Reflect + Send + 'static + GetTypeRegistration,
+        T: Event + Default + Resource + Reflect + Send + Clone + 'static + GetTypeRegistration,
     >(
         &mut self,
     ) -> &mut Self;
@@ -344,7 +345,7 @@ impl EditorRegistryExt for App {
     }
 
     fn editor_registry_event<
-        T: Event + Default + Resource + Reflect + Send + 'static + GetTypeRegistration,
+        T: Event + Default + Resource + Reflect + Send + Clone + 'static + GetTypeRegistration,
     >(
         &mut self,
     ) -> &mut Self {

--- a/crates/prefab/src/editor_registry/mod.rs
+++ b/crates/prefab/src/editor_registry/mod.rs
@@ -349,8 +349,11 @@ impl EditorRegistryExt for App {
     >(
         &mut self,
     ) -> &mut Self {
-        self.register_type::<T>();
-        self.world.init_resource::<T>();
+        #[cfg(not(feature = "no_event_registration"))]
+        {
+            self.register_type::<T>();
+            self.world.init_resource::<T>();
+        }
         self.world
             .resource_mut::<EditorRegistry>()
             .event_register::<T>();

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ space_editor is useful tool for scene/prefab/prototyping with bevy engine.  Its 
 - **Prefab Reusability**: Prefabs can be nested within other prefabs, improving reusability and organization in your projects. 
 - **Many custom components**: Space Editor implements various custom components to seamlessly integrate its saving system with the standard Bevy scene format. 
 - **Easy API for customization**: Customize or register your own components within the editor with ease, tailoring it to your specific project needs.
-- **Event debugging**: Send events directly from the editor UI for easier gameplay debugging.  
+- **Event dispatching**: Send custom events directly from the editor UI for easier gameplay debugging. 
 - **API for adding tabs**: Extend the functionality of the editor by easily adding new tabs, enhancing your workflow. 
 
 # Editor UI
@@ -115,15 +115,25 @@ The representation of components in the editor UI can also be customized by bevy
 
 ## Register new event
 
-Events can be added to the editor gui with the following:
+Custom Events can be added to the editor UI with the following:
 
 ```rs
+#[derive(Event, Default, Resource, Reflect, Clone)]
+#[reflect(Resource)]
+pub struct Name;
+
 use editor::prelude::EditorRegistryExt;
 
 app.editor_registry_event::<Name>();
 ```
 
-One limitation is that events must implement `Default`. Once registered, events can be sent using the `Event Debugger` tab. 
+One limitation is that events must implement `Event, Default, Resource, Reflect, Clone`, with `Resource` reflected. Once registered, events can be sent using the `Event Dispatcher` tab.
+
+> Obs: editor already handles internally objects registration and initialization:
+> 
+> `register_type::<T>() and init_resource::<T>()`
+
+> To disable this, use feature `no_event_registration`.
 
 ## Bundles
 

--- a/examples/custom_event.rs
+++ b/examples/custom_event.rs
@@ -6,7 +6,7 @@
 use bevy::prelude::*;
 use space_editor::prelude::*;
 
-#[derive(Event, Default, Resource, Reflect)]
+#[derive(Event, Default, Resource, Reflect, Clone)]
 #[reflect(Resource)]
 pub struct ToggleSpin {
     speed: f32,

--- a/examples/custom_event.rs
+++ b/examples/custom_event.rs
@@ -1,7 +1,7 @@
 // Simple event example
-// Open the "Event Debugger" tab to send the "ToggleSpin" event.
+// Open the ["Event Dispacther" tab](https://github.com/rewin123/space_editor/pull/163) to send the "ToggleSpin" event.
 // Run command:
-// cargo run --example event_example
+// cargo run --example custom_event
 
 use bevy::prelude::*;
 use space_editor::prelude::*;


### PR DESCRIPTION
This PR is supposed to be the continuation of [this commit 8d8d9ae72](https://github.com/rewin123/space_editor/commit/8d8d9ae72fa45e91b2209437f3dbbd4365c2d218).
Addresses https://github.com/rewin123/space_editor/issues/158 

- [x] Renamed Event Debugger to Event Dispatcher, as it is how Unreal Engine calls it.
- [x] Bevy Events are not yet supported :( 
- [x] More derive traits are necessary due to some workaround to avoid dangerous unsafe calls.
```rs
// examples/custom_event
#[derive(Event, Default, Resource, Reflect, Clone)]
#[reflect(Resource)]
pub struct ToggleSpin {
    speed: f32,
}
```
- [x] Documentation

https://github.com/rewin123/space_editor/assets/14813660/b92433e7-c3a2-415a-92cf-ee74cc268f6e

