### PR TITLE
UX Pass `Show editor entities`

### DIFF
--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -117,7 +117,7 @@ pub fn show_hierarchy(
                     commands.entity(entity).despawn_recursive();
 
                     changes.send(NewChange {
-                        change: Arc::new(RemovedEntity { entity: entity }),
+                        change: Arc::new(RemovedEntity { entity }),
                     });
                 }
             }

--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -101,8 +101,11 @@ pub fn show_hierarchy(
                 }
             }
         }
-        ui.vertical_centered(|ui| {
-            ui.separator();
+
+        ui.spacing();
+        ui.separator();
+        ui.checkbox(&mut state.show_editor_entities, "Show editor entities");
+        ui.vertical_centered_justified(|ui| {
             if ui.button("+ Add new entity").clicked() {
                 let id = commands.spawn_empty().insert(PrefabMarker).id();
                 changes.send(NewChange {
@@ -120,7 +123,7 @@ pub fn show_hierarchy(
             }
         });
 
-        ui.checkbox(&mut state.show_editor_entities, "Show editor entities");
+        ui.spacing();
 
         ui.label("Spawnable bundles");
         for (category_name, category_bundle) in ui_reg.bundles.iter() {

--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -45,7 +45,7 @@ impl Plugin for SpaceHierarchyPlugin {
 
 #[derive(Resource, Default)]
 pub struct HierarchyTabState {
-    show_all_entities: bool,
+    show_editor_entities: bool,
 }
 
 type HierarchyQueryIter<'a> = (
@@ -67,7 +67,7 @@ pub fn show_hierarchy(
     mut changes: EventWriter<NewChange>,
     mut state: ResMut<HierarchyTabState>,
 ) {
-    let mut all: Vec<_> = if state.show_all_entities {
+    let mut all: Vec<_> = if state.show_editor_entities {
         all_entites.iter().collect()
     } else {
         query.iter().collect()
@@ -78,7 +78,7 @@ pub fn show_hierarchy(
     egui::ScrollArea::vertical().show(ui, |ui| {
         for (entity, _name, _children, parent) in all.iter() {
             if parent.is_none() {
-                if state.show_all_entities {
+                if state.show_editor_entities {
                     draw_entity::<()>(
                         &mut commands,
                         ui,
@@ -110,17 +110,17 @@ pub fn show_hierarchy(
                 });
             }
             if ui.button("Clear all entities").clicked() {
-                for (entity, _, _, _parent) in all.iter() {
-                    commands.entity(*entity).despawn_recursive();
+                for (entity, _, _, _parent) in query.iter() {
+                    commands.entity(entity).despawn_recursive();
 
                     changes.send(NewChange {
-                        change: Arc::new(RemovedEntity { entity: *entity }),
+                        change: Arc::new(RemovedEntity { entity: entity }),
                     });
                 }
             }
         });
 
-        ui.checkbox(&mut state.show_all_entities, "Show all entities");
+        ui.checkbox(&mut state.show_editor_entities, "Show editor entities");
 
         ui.label("Spawnable bundles");
         for (category_name, category_bundle) in ui_reg.bundles.iter() {

--- a/crates/editor_ui/src/lib.rs
+++ b/crates/editor_ui/src/lib.rs
@@ -282,15 +282,18 @@ pub trait FlatPluginList {
 pub fn simple_editor_setup(mut commands: Commands) {
     commands.insert_resource(bevy::pbr::DirectionalLightShadowMap { size: 4096 });
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            shadows_enabled: true,
+    commands.spawn((
+        DirectionalLightBundle {
+            directional_light: DirectionalLight {
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+            cascade_shadow_config: CascadeShadowConfigBuilder::default().into(),
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
-        cascade_shadow_config: CascadeShadowConfigBuilder::default().into(),
-        ..default()
-    });
+        Name::from("Editor Level Light"),
+    ));
 
     // grid
     let grid_render_layer = RenderLayers::layer(LAST_RENDER_LAYER);
@@ -309,6 +312,7 @@ pub fn simple_editor_setup(mut commands: Commands) {
         TrackedGrid::default(),
         TransformBundle::default(),
         VisibilityBundle::default(),
+        Name::from("Debug Grid"),
         grid_render_layer,
     ));
 


### PR DESCRIPTION
- [x] Renames `show all entities` to `show editor entities``
- [x] Adds Name to most Editor entities
- [x]  Prevents deleting/clearing editor entities with `clear all entities` 


<img width="427" alt="Captura de Tela 2024-01-21 às 10 02 35 PM" src="https://github.com/rewin123/space_editor/assets/14813660/de76fca3-08b2-4f9f-a47a-1058bf8d10a3">
