### PR TITLE
Bevy mesh terrain integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+### TODO 
+
+- be able to use the same kind of assets structure to  load in the unit type and unit model information
+- be able to place those units in the scene using the normal tools 
+- be able to save to a RON file using the format of my choice 
+
+- allow for loading in the terrain so i can use it as a reference 

--- a/crates/editor_ui/src/camera_plugin.rs
+++ b/crates/editor_ui/src/camera_plugin.rs
@@ -18,6 +18,7 @@ impl Plugin for EditorDefaultCameraPlugin {
                 .before(PanOrbitCameraSystemSet)
                 .in_set(EditorSet::Editor),
         );
+   
         app.add_systems(
             Update,
             ui_camera_block

--- a/crates/editor_ui/src/tool.rs
+++ b/crates/editor_ui/src/tool.rs
@@ -1,8 +1,15 @@
+use std::any::Any;
+
 use bevy::prelude::*;
 
 use crate::prelude::GameViewTab;
 
 pub trait EditorTool {
+    
+      fn as_any(&self) -> &dyn Any;
+      
+      
+      
     fn ui(&mut self, ui: &mut bevy_egui_next::egui::Ui, commands: &mut Commands, world: &mut World);
     fn name(&self) -> &str;
 }
@@ -44,3 +51,5 @@ impl ToolExt for App {
             .push(Box::new(tool));
     }
 }
+
+

--- a/crates/editor_ui/src/tools/gizmo.rs
+++ b/crates/editor_ui/src/tools/gizmo.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use bevy::{prelude::*, render::camera::CameraProjection};
 use bevy_egui_next::egui::{self, Key};
 use egui_gizmo::*;
@@ -66,6 +68,10 @@ impl Default for GizmoTool {
 impl EditorTool for GizmoTool {
     fn name(&self) -> &str {
         "Gizmo"
+    }
+    
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, commands: &mut Commands, world: &mut World) {

--- a/modules/bevy_mesh_terrain_plugin/src/lib.rs
+++ b/modules/bevy_mesh_terrain_plugin/src/lib.rs
@@ -1,18 +1,33 @@
 pub mod terrain_tab;
 pub mod terrain_tool;
+pub mod terrain_chunks;
+pub mod terrain_brush;
 
-use bevy::prelude::*;
-use space_editor_ui::prelude::*;
+use bevy::prelude::*; 
 use bevy_mesh_terrain::terrain::TerrainViewer;
+use terrain_tool::TerrainTools;
+
+use space_editor_ui::{prelude::*, ext::bevy_mod_picking::backends::raycast::bevy_mod_raycast::{CursorRay, prelude::Raycast, DefaultRaycastingPlugin}};
+
+
+
 
 pub struct BevyMeshTerrainPlugin;
 
 impl Plugin for BevyMeshTerrainPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((
+        app
+        
+        
+       // .init_resource::<TerrainTools>()
+          .add_plugins(DefaultRaycastingPlugin)
+          
+        .add_plugins((
             bevy_mesh_terrain::TerrainMeshPlugin::default(),
             terrain_tab::TerrainTabPlugin,
-            terrain_tool::TerrainToolPlugin
+            terrain_tool::TerrainToolPlugin,
+            terrain_chunks::TerrainChunksPlugin,
+            terrain_brush::TerrainBrushPlugin
         ));
 
         app.add_systems(Update, add_viewer_to_editor_cams);

--- a/modules/bevy_mesh_terrain_plugin/src/terrain_brush.rs
+++ b/modules/bevy_mesh_terrain_plugin/src/terrain_brush.rs
@@ -1,0 +1,136 @@
+
+
+
+
+use bevy::prelude::*;
+use bevy_inspector_egui::bevy_egui_next::EguiContexts;
+use bevy_mesh_terrain::{edit::TerrainCommandEvent,
+     terrain::TerrainData, 
+    terrain_config::TerrainConfig, 
+    chunk::{Chunk,ChunkData}};
+use space_editor_ui::{prelude::*, ext::bevy_mod_picking::backends::raycast::bevy_mod_raycast::{CursorRay, prelude::Raycast, DefaultRaycastingPlugin}};
+
+
+
+use bevy_mesh_terrain::edit::{EditingTool,BrushType,EditTerrainEvent};
+use crate::{terrain_tool::{ToolMode,TerrainTools}, terrain_chunks::BrushableTerrain};
+
+pub struct TerrainBrushPlugin;
+
+impl Plugin for TerrainBrushPlugin {
+    fn build(&self, app: &mut App) {
+        app 
+        
+         
+         .add_systems(Update,  update_brush_paint )
+         ;
+    }
+}
+  
+  
+#[derive(Debug)]
+struct EditingToolData {
+    editing_tool: EditingTool,
+    brush_type: BrushType,
+    brush_radius: f32,
+    brush_hardness: f32,
+}
+
+impl From<TerrainTools> for EditingToolData {
+    fn from(state: TerrainTools) -> Self {
+        let editing_tool = EditingTool::from(state.clone());
+
+        Self {
+            editing_tool,
+            brush_radius: state.brush_radius as f32,
+            brush_type: state.brush_type,
+            brush_hardness: (state.brush_hardness as f32) / 100.0,
+        }
+    }
+}
+
+impl From<TerrainTools> for EditingTool {
+    fn from(state: TerrainTools) -> Self {
+        match state.tool_mode {
+            ToolMode::Height => EditingTool::SetHeightMap {
+                height: state.color.r,
+            },
+            ToolMode::Splat => EditingTool::SetSplatMap {
+                r: state.color.r as u8,
+                g: state.color.g as u8,
+                b: state.color.b as u8,
+            },
+        }
+    }
+}
+
+
+pub fn update_brush_paint(
+    mouse_input: Res<Input<MouseButton>>, //detect mouse click
+
+    cursor_ray: Res<CursorRay>,
+    mut raycast: Raycast,
+
+    mut edit_event_writer: EventWriter<EditTerrainEvent>, 
+    
+    editor_tools_state: Res<TerrainTools>,
+    
+    brushable_terrain_query: Query<Entity, With<BrushableTerrain>>,
+
+
+    mut contexts: EguiContexts,
+) {
+    if !mouse_input.pressed(MouseButton::Left) {
+        return;
+    }
+
+    let egui_ctx = contexts.ctx_mut();
+    if egui_ctx.is_pointer_over_area() {
+        return;
+    }
+
+ 
+
+    let tool_data: EditingToolData = (*editor_tools_state).clone().into();
+
+     println!("brushing terrain w tool {:?}",tool_data  );
+            
+            
+    let radius = tool_data.brush_radius;
+    let brush_hardness = tool_data.brush_hardness;
+    let brush_type = tool_data.brush_type;
+
+    // let tool = EditingTool::SetSplatMap(5,1,0,25.0,false);
+
+    if let Some(cursor_ray) = **cursor_ray {
+        if let Some((intersection_entity, intersection_data)) =
+            raycast.cast_ray(cursor_ray, &default()).first()
+        {
+            
+            //if we raycast to a brushable terrain, send terrain edit events 
+            if brushable_terrain_query.get(*intersection_entity).ok().is_some(){
+                
+         
+            
+            let hit_point = intersection_data.position();
+
+            //offset this by the world psn offset of the entity !? would need to query its transform ?  for now assume 0 offset.
+            let hit_coordinates = Vec2::new(hit_point.x, hit_point.z);
+
+            //use an event to pass the entity and hit coords to the terrain plugin so it can edit stuff there
+
+                println!("brushing terrain at {:?}" , hit_coordinates );
+            
+            edit_event_writer.send(EditTerrainEvent {
+                entity: intersection_entity.clone(),
+                tool: tool_data.editing_tool,
+                brush_type,
+                brush_hardness,
+                coordinates: hit_coordinates,
+                radius,
+            });
+            
+            }
+        }
+    }
+}

--- a/modules/bevy_mesh_terrain_plugin/src/terrain_brush.rs
+++ b/modules/bevy_mesh_terrain_plugin/src/terrain_brush.rs
@@ -73,7 +73,9 @@ pub fn update_brush_paint(
 
     mut edit_event_writer: EventWriter<EditTerrainEvent>, 
     
-    editor_tools_state: Res<TerrainTools>,
+   // editor_tools_state: Res<TerrainTools>,
+ game_view_tab: Res<GameViewTab>,
+    //world: Res<World>,
     
     brushable_terrain_query: Query<Entity, With<BrushableTerrain>>,
 
@@ -88,49 +90,66 @@ pub fn update_brush_paint(
     if egui_ctx.is_pointer_over_area() {
         return;
     }
-
- 
-
-    let tool_data: EditingToolData = (*editor_tools_state).clone().into();
-
-     println!("brushing terrain w tool {:?}",tool_data  );
+    
+    let active_tool_index = game_view_tab.active_tool .unwrap_or_default();
+     
+    
+    if let Some(active_tool) = game_view_tab.tools.get(active_tool_index){
+        
+        
+        if let Some(tools_state) = active_tool.as_any().downcast_ref::<TerrainTools>() {
+    // `tool` is now a reference to `TerrainTool`
+        println!("Active tool is a TerrainTool!");
+        // You can now use `tool` as a `TerrainTool` 
+      
+                    
+                let tool_data: EditingToolData = ( tools_state).clone().into();
             
-            
-    let radius = tool_data.brush_radius;
-    let brush_hardness = tool_data.brush_hardness;
-    let brush_type = tool_data.brush_type;
-
-    // let tool = EditingTool::SetSplatMap(5,1,0,25.0,false);
-
-    if let Some(cursor_ray) = **cursor_ray {
-        if let Some((intersection_entity, intersection_data)) =
-            raycast.cast_ray(cursor_ray, &default()).first()
-        {
-            
-            //if we raycast to a brushable terrain, send terrain edit events 
-            if brushable_terrain_query.get(*intersection_entity).ok().is_some(){
+                println!("brushing terrain w tool {:?}",tool_data  );
+                        
                 
-         
+                let radius = tool_data.brush_radius;
+                let brush_hardness = tool_data.brush_hardness;
+                let brush_type = tool_data.brush_type;
             
-            let hit_point = intersection_data.position();
-
-            //offset this by the world psn offset of the entity !? would need to query its transform ?  for now assume 0 offset.
-            let hit_coordinates = Vec2::new(hit_point.x, hit_point.z);
-
-            //use an event to pass the entity and hit coords to the terrain plugin so it can edit stuff there
-
-                println!("brushing terrain at {:?}" , hit_coordinates );
+                // let tool = EditingTool::SetSplatMap(5,1,0,25.0,false);
             
-            edit_event_writer.send(EditTerrainEvent {
-                entity: intersection_entity.clone(),
-                tool: tool_data.editing_tool,
-                brush_type,
-                brush_hardness,
-                coordinates: hit_coordinates,
-                radius,
-            });
+                if let Some(cursor_ray) = **cursor_ray {
+                    if let Some((intersection_entity, intersection_data)) =
+                        raycast.cast_ray(cursor_ray, &default()).first()
+                    {
+                        
+                        //if we raycast to a brushable terrain, send terrain edit events 
+                        if brushable_terrain_query.get(*intersection_entity).ok().is_some(){
+                            
+                    
+                        
+                        let hit_point = intersection_data.position();
             
-            }
+                        //offset this by the world psn offset of the entity !? would need to query its transform ?  for now assume 0 offset.
+                        let hit_coordinates = Vec2::new(hit_point.x, hit_point.z);
+            
+                        //use an event to pass the entity and hit coords to the terrain plugin so it can edit stuff there
+            
+                            println!("brushing terrain at {:?}" , hit_coordinates );
+                        
+                        edit_event_writer.send(EditTerrainEvent {
+                            entity: intersection_entity.clone(),
+                            tool: tool_data.editing_tool,
+                            brush_type,
+                            brush_hardness,
+                            coordinates: hit_coordinates,
+                            radius,
+                        });
+                        
+                        }
+                    }
+                }
+                
+    
+    
+    
+    
         }
     }
 }

--- a/modules/bevy_mesh_terrain_plugin/src/terrain_chunks.rs
+++ b/modules/bevy_mesh_terrain_plugin/src/terrain_chunks.rs
@@ -1,0 +1,38 @@
+
+
+
+
+use bevy::prelude::*;
+use bevy_mesh_terrain::{edit::TerrainCommandEvent,
+     terrain::TerrainData, 
+    terrain_config::TerrainConfig, 
+    chunk::{Chunk,ChunkData, TerrainChunkMesh}};
+use space_editor_ui::prelude::*;
+
+pub struct TerrainChunksPlugin;
+
+impl Plugin for TerrainChunksPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update,  add_brushable_terrain_components );
+    }
+}
+
+#[derive(Component)]
+pub struct BrushableTerrain {}
+
+
+fn add_brushable_terrain_components( 
+    mut commands: Commands,
+    chunks_query: Query<(Entity,&TerrainChunkMesh), Without<BrushableTerrain>>
+    
+){
+    
+    for (entity,_) in chunks_query.iter(){
+        
+        commands.entity(entity).insert(
+            BrushableTerrain{}
+        );
+        
+    }
+    
+}

--- a/modules/bevy_mesh_terrain_plugin/src/terrain_tool.rs
+++ b/modules/bevy_mesh_terrain_plugin/src/terrain_tool.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Formatter};
+use std::{fmt::{self, Formatter}, any::Any};
 
 use bevy::prelude::*;
 use bevy_inspector_egui::egui;
@@ -26,6 +26,10 @@ pub struct TerrainTools {
 }
 
 impl EditorTool for TerrainTools {
+      fn as_any(&self) -> &dyn Any {
+        self
+    }
+    
     fn ui(&mut self, ui: &mut bevy_inspector_egui::bevy_egui_next::egui::Ui, commands: &mut Commands, world: &mut World) {
         ui.vertical(|ui| {
             ui.heading("Tool Mode");


### PR DESCRIPTION
Hi @rewin 
 

okay i got it working !! but i had to do something funky with downcasting so if you want to change the way the EditorTools work to avoid that then you can do that .
now it works 😄 😄   it is a bit funky because 

1) the chunks highlight white when brushing which is annoying , could use a WIthout<BrushableTerrain> to avoid  this 
2) the camera orbits around while brushing ... i avoid this in my editor by reserving Left Click to brushing and not panning or orbiting the camera ,, and i use WASD to fly 
3) if you click a lot while brushing, its possible to make the editor crash because one of your systems is trying to do something to my chunk which gets removed (its entity)  in another thread.   May have to use  try_insert or something creative there idk .  my chunk entities do get auto-removed in an async thread  so that is likely related. 