### PR TITLE
Miserably failing cargo-deny

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,10 +112,3 @@ jobs:
           components: rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
-
-  # Denies non open source standards
-  cargo-deny:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,3 +112,10 @@ jobs:
           components: rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+  # Denies non open source standards
+  cargo-deny:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,57 @@
+name: Dependencies
+
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'deny.toml'
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - 'deny.toml'
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for security advisories and unmaintained crates
+        run: cargo deny check advisories
+
+  check-bans:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for banned and duplicated dependencies
+        run: cargo deny check bans
+
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for unauthorized licenses
+        run: cargo deny check licenses
+
+  check-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Checked for unauthorized crate sources
+        run: cargo deny check sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,84 @@
+# SAME AS BEVY
+all-features = true
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+copyleft = "deny"
+default = "deny"
+allow = [
+  "MIT",
+  "MIT-0",
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "0BSD",
+  "BSD-2-Clause",
+  "CC0-1.0",
+]
+exceptions = [
+  { name = "unicode-ident", allow = [
+    "Unicode-DFS-2016",
+  ] },
+  { name = "symphonia-bundle-flac", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-bundle-mp3", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-aac", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-adpcm", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-pcm", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-vorbis", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-core", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-format-isomp4", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-format-wav", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-metadata", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-utils-xiph", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia", allow = [
+    "MPL-2.0",
+  ] },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# Certain crates that we don't want multiple versions of in the dependency tree
+deny = [
+  { name = "ahash", deny-multiple-versions = true },
+  { name = "android-activity", deny-multiple-versions = true },
+  { name = "glam", deny-multiple-versions = true },
+  { name = "raw-window-handle", deny-multiple-versions = true },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
To be compatible as a bevy editor, we need to follow their cargo-deny parameters. Therefore, I have added the followinf file to our project https://github.com/bevyengine/bevy/blob/main/deny.toml using cargo-deny-action