### PR TITLE
Adds toast support for user centered error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,9 @@ convert_case = "0.6"
 egui_dock = "0.11"
 egui_extras = { version = "0.26", features = ["all_loaders"] }
 egui_file = "0.15"
-image = {version = "0.24.8", feature = ["png"] }
 egui-gizmo = "0.16.1"
+egui-toast = "0.12.1"
+image = {version = "0.24.8", feature = ["png"] }
 
 pretty-type-name = "1"
 ron = "0.8"

--- a/crates/editor_core/Cargo.toml
+++ b/crates/editor_core/Cargo.toml
@@ -18,6 +18,10 @@ space_undo.workspace = true
 space_persistence.workspace = true
 space_shared.workspace = true
 
+bevy_egui_next.workspace = true
+egui_dock.workspace = true
+egui-toast.workspace = true
+
 [features]
 persistence_editor = []
 

--- a/crates/editor_core/src/lib.rs
+++ b/crates/editor_core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod hotkeys;
 mod load;
 pub mod selected;
 pub mod task_storage;
+pub mod toast;
 
 pub mod prelude {
     pub use super::*;

--- a/crates/editor_core/src/toast.rs
+++ b/crates/editor_core/src/toast.rs
@@ -303,6 +303,7 @@ mod tests {
         app.update();
 
         app.world.send_event(ClearToastMessage::all());
+        app.update();
 
         let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
         assert!(!storage.has_toasts());

--- a/crates/editor_core/src/toast.rs
+++ b/crates/editor_core/src/toast.rs
@@ -7,16 +7,47 @@ pub struct ToastUiPlugin;
 
 impl Plugin for ToastUiPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ToastStorage>()
-            .add_event::<ToastMessage>()
-            .add_systems(Update, read_toast)
+        app.add_plugins(ToastBasePlugin)
             .add_systems(PostUpdate, show_toast);
     }
 }
 
+struct ToastBasePlugin;
+
+impl Plugin for ToastBasePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ToastStorage>()
+            .add_event::<ToastMessage>()
+            .add_event::<ClearToastMessage>()
+            .add_systems(Update, read_toast)
+            .add_systems(PostUpdate, clear_toasts);
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ToastsPerKind {
+    pub warning: Vec<String>,
+    pub error: Vec<String>,
+}
+
 #[derive(Resource)]
-struct ToastStorage {
+pub struct ToastStorage {
     toasts: Toasts,
+    pub toasts_per_kind: ToastsPerKind,
+}
+
+impl ToastStorage {
+    fn add(&mut self, message: &ToastMessage) {
+        match &message.kind {
+            ToastKind::Warning => self.toasts_per_kind.warning.push(message.text.clone()),
+            ToastKind::Error => self.toasts_per_kind.error.push(message.text.clone()),
+            _ => (),
+        }
+    }
+
+    pub fn has_toasts(&self) -> bool {
+        !self.toasts_per_kind.warning.is_empty() || !self.toasts_per_kind.error.is_empty()
+    }
 }
 
 impl Default for ToastStorage {
@@ -25,6 +56,7 @@ impl Default for ToastStorage {
             toasts: Toasts::new()
                 .anchor(Align2::RIGHT_TOP, (-10.0, 10.0))
                 .direction(egui::Direction::TopDown),
+            toasts_per_kind: ToastsPerKind::default(),
         }
     }
 }
@@ -33,6 +65,39 @@ impl Default for ToastStorage {
 pub struct ToastMessage {
     text: String,
     kind: ToastKind,
+}
+
+#[derive(Event)]
+pub struct ClearToastMessage {
+    index: usize,
+    kind: ToastKind,
+    all: bool,
+}
+
+impl ClearToastMessage {
+    pub const fn error(index: usize) -> Self {
+        Self {
+            index,
+            kind: ToastKind::Error,
+            all: false,
+        }
+    }
+
+    pub const fn warn(index: usize) -> Self {
+        Self {
+            index,
+            kind: ToastKind::Warning,
+            all: false,
+        }
+    }
+
+    pub const fn all() -> Self {
+        Self {
+            index: 0,
+            kind: ToastKind::Error,
+            all: true,
+        }
+    }
 }
 
 impl ToastMessage {
@@ -46,11 +111,7 @@ impl ToastMessage {
 
 impl From<&ToastMessage> for Toast {
     fn from(value: &ToastMessage) -> Self {
-        let duration = match &value.kind {
-            ToastKind::Warning => 6.,
-            ToastKind::Error => 10.,
-            _ => 4.,
-        };
+        let duration = toast_kind_to_duration(value);
         Self {
             text: value.text.clone().into(),
             kind: value.kind,
@@ -62,11 +123,43 @@ impl From<&ToastMessage> for Toast {
     }
 }
 
+const fn toast_kind_to_duration(value: &ToastMessage) -> f64 {
+    match &value.kind {
+        ToastKind::Warning => 6.,
+        ToastKind::Error => 10.,
+        _ => 4.,
+    }
+}
+
 fn read_toast(mut events: EventReader<ToastMessage>, mut storage: ResMut<ToastStorage>) {
     for event in events.read() {
+        storage.add(event);
         storage.toasts.add(event.into());
     }
 
+    events.clear();
+}
+
+fn clear_toasts(mut events: EventReader<ClearToastMessage>, mut storage: ResMut<ToastStorage>) {
+    for event in events.read() {
+        if event.all {
+            storage.toasts_per_kind = ToastsPerKind::default();
+        } else {
+            match event.kind {
+                ToastKind::Warning => {
+                    if event.index < storage.toasts_per_kind.warning.len() {
+                        storage.toasts_per_kind.warning.remove(event.index);
+                    }
+                }
+                ToastKind::Error => {
+                    if event.index < storage.toasts_per_kind.error.len() {
+                        storage.toasts_per_kind.error.remove(event.index);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
     events.clear();
 }
 
@@ -76,4 +169,142 @@ fn show_toast(
 ) {
     let mut ctx = ctxs.single_mut();
     storage.toasts.show(ctx.get_mut());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_toast_message() {
+        let message = ToastMessage::new("Test message", ToastKind::Info);
+        assert_eq!(message.text, "Test message");
+        assert_eq!(message.kind, ToastKind::Info);
+    }
+
+    #[test]
+    fn from_toast_message() {
+        let message = ToastMessage::new("Test message", ToastKind::Info);
+        let toast = Toast::from(&message);
+        assert_eq!(toast.text.text(), message.text);
+        assert_eq!(toast.kind, message.kind);
+        assert_eq!(toast.options.show_icon, true);
+        assert_eq!(toast.options.show_progress, false);
+        assert_eq!(toast.options.progress(), 1.);
+    }
+
+    #[test]
+    fn toast_kinds_to_durations() {
+        assert_eq!(
+            toast_kind_to_duration(&ToastMessage::new("Test message", ToastKind::Info)),
+            4.
+        );
+        assert_eq!(
+            toast_kind_to_duration(&ToastMessage::new("Test message", ToastKind::Warning)),
+            6.
+        );
+        assert_eq!(
+            toast_kind_to_duration(&ToastMessage::new("Test message", ToastKind::Error)),
+            10.
+        );
+    }
+
+    #[test]
+    fn toast_plugin_received_event() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, ToastBasePlugin));
+
+        app.update();
+        assert!(!app
+            .world
+            .get_resource::<ToastStorage>()
+            .unwrap()
+            .has_toasts());
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.update();
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.update();
+
+        let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
+        assert_eq!(storage.toasts_per_kind.error.len(), 3);
+        assert_eq!(storage.toasts_per_kind.warning.len(), 3);
+        assert!(storage.has_toasts());
+    }
+
+    #[test]
+    fn clear_toasts() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, ToastBasePlugin));
+
+        app.update();
+        assert!(!app
+            .world
+            .get_resource::<ToastStorage>()
+            .unwrap()
+            .has_toasts());
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.update();
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.update();
+
+        app.world.send_event(ClearToastMessage::error(1));
+        app.world.send_event(ClearToastMessage::warn(1));
+        app.update();
+
+        let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
+        assert_eq!(storage.toasts_per_kind.error.len(), 2);
+        assert_eq!(storage.toasts_per_kind.warning.len(), 2);
+    }
+
+    #[test]
+    fn clear_all_toasts() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, ToastBasePlugin));
+
+        app.update();
+        assert!(!app
+            .world
+            .get_resource::<ToastStorage>()
+            .unwrap()
+            .has_toasts());
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Error));
+        app.update();
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Warning));
+        app.update();
+
+        app.world.send_event(ClearToastMessage::all());
+
+        let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
+        assert!(!storage.has_toasts());
+    }
 }

--- a/crates/editor_core/src/toast.rs
+++ b/crates/editor_core/src/toast.rs
@@ -1,0 +1,79 @@
+use bevy::{prelude::*, window::PrimaryWindow};
+use bevy_egui_next::EguiContext;
+use egui_dock::egui::{self, Align2};
+
+pub use egui_toast::*;
+pub struct ToastUiPlugin;
+
+impl Plugin for ToastUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ToastStorage>()
+            .add_event::<ToastMessage>()
+            .add_systems(Update, read_toast)
+            .add_systems(PostUpdate, show_toast);
+    }
+}
+
+#[derive(Resource)]
+struct ToastStorage {
+    toasts: Toasts,
+}
+
+impl Default for ToastStorage {
+    fn default() -> Self {
+        Self {
+            toasts: Toasts::new()
+                .anchor(Align2::RIGHT_TOP, (-10.0, 10.0))
+                .direction(egui::Direction::TopDown),
+        }
+    }
+}
+
+#[derive(Event)]
+pub struct ToastMessage {
+    text: String,
+    kind: ToastKind,
+}
+
+impl ToastMessage {
+    pub fn new(text: &str, kind: ToastKind) -> Self {
+        Self {
+            text: text.to_string(),
+            kind,
+        }
+    }
+}
+
+impl From<&ToastMessage> for Toast {
+    fn from(value: &ToastMessage) -> Self {
+        let duration = match &value.kind {
+            ToastKind::Warning => 6.,
+            ToastKind::Error => 10.,
+            _ => 4.,
+        };
+        Self {
+            text: value.text.clone().into(),
+            kind: value.kind,
+            options: ToastOptions::default()
+                .show_icon(true)
+                .duration_in_seconds(duration)
+                .show_progress(false),
+        }
+    }
+}
+
+fn read_toast(mut events: EventReader<ToastMessage>, mut storage: ResMut<ToastStorage>) {
+    for event in events.read() {
+        storage.toasts.add(event.into());
+    }
+
+    events.clear();
+}
+
+fn show_toast(
+    mut storage: ResMut<ToastStorage>,
+    mut ctxs: Query<&mut EguiContext, With<PrimaryWindow>>,
+) {
+    let mut ctx = ctxs.single_mut();
+    storage.toasts.show(ctx.get_mut());
+}

--- a/crates/editor_ui/src/lib.rs
+++ b/crates/editor_ui/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-//This module contains ui logics, which will be work through events with editor core module and prefab module
+/// This module contains ui logics, which will be work through events with editor core module and prefab module
 mod mouse_check;
 
 /// This module will be used to create Unity like project file dialog. Currently NOT USED
@@ -89,6 +89,7 @@ use prelude::{
     GameModeSettings, GameViewTab, MeshlessVisualizerPlugin, NewTabBehaviour, NewWindowSettings,
     ScheduleEditorTab, ScheduleEditorTabStorage, SpaceHierarchyPlugin, SpaceInspectorPlugin,
 };
+use space_editor_core::toast::ToastUiPlugin;
 use space_prefab::prelude::*;
 use space_shared::{
     ext::bevy_inspector_egui::{quick::WorldInspectorPlugin, DefaultInspectorConfigPlugin},
@@ -148,6 +149,7 @@ pub struct EditorPluginGroup;
 impl PluginGroup for EditorPluginGroup {
     fn build(self) -> bevy::app::PluginGroupBuilder {
         let mut res = PluginGroupBuilder::start::<Self>()
+            .add(ToastUiPlugin)
             .add(UndoPlugin)
             .add(SyncUndoMarkersPlugin::<PrefabMarker>::default())
             .add(PrefabPlugin)

--- a/crates/editor_ui/src/menu_toolbars.rs
+++ b/crates/editor_ui/src/menu_toolbars.rs
@@ -5,7 +5,11 @@ use bevy_egui_next::{
     egui::{Align, Align2, Margin, Pos2, Stroke, Widget},
     *,
 };
-use space_editor_core::prelude::*;
+use egui_dock::egui::RichText;
+use space_editor_core::{
+    prelude::*,
+    toast::{ClearToastMessage, ToastStorage},
+};
 use space_prefab::plugins::PrefabPlugin;
 use space_shared::{ext::egui_file, *};
 use space_undo::{AddedEntity, NewChange, RemovedEntity};
@@ -128,6 +132,7 @@ pub struct MenuToolbarState {
     pub gltf_dialog: Option<egui_file::FileDialog>,
     pub save_dialog: Option<egui_file::FileDialog>,
     pub load_dialog: Option<egui_file::FileDialog>,
+    show_toasts: bool,
     pub path: String,
 }
 
@@ -261,7 +266,9 @@ pub fn top_menu(
     mut events: EventReader<MenuLoadEvent>,
     mut menu_state: ResMut<MenuToolbarState>,
     mut editor_events: EventWriter<EditorEvent>,
+    mut clear_toast: EventWriter<ClearToastMessage>,
     background_tasks: Res<BackgroundTaskStorage>,
+    toasts: Res<ToastStorage>,
     sizing: Res<Sizing>,
 ) {
     let ctx = ctxs.ctx_mut();
@@ -468,6 +475,61 @@ pub fn top_menu(
                 }
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
+                    if toasts.has_toasts() {
+                        egui::Window::new("Errors")
+                            .anchor(Align2::RIGHT_TOP, egui::Vec2::new(-16., 32.))
+                            .movable(true)
+                            .resizable(true)
+                            .open(&mut menu_state.show_toasts)
+                            .show(ctx, |ui| {
+                                ui.vertical_centered_justified(|ui| {
+                                    if ui.add(egui::Button::new("Clear all 🗑")).clicked() {
+                                        clear_toast.send(ClearToastMessage::all())
+                                    };
+                                });
+                                egui::Grid::new("error_console_log").show(ui, |ui| {
+                                    for (index, error) in
+                                        toasts.toasts_per_kind.error.iter().enumerate()
+                                    {
+                                        ui.label(RichText::new("ERROR").color(ERROR_COLOR));
+                                        ui.label(error);
+                                        if ui.button("🗙").clicked() {
+                                            clear_toast.send(ClearToastMessage::error(index))
+                                        }
+                                        ui.end_row();
+                                    }
+                                    for (index, warning) in
+                                        toasts.toasts_per_kind.warning.iter().enumerate()
+                                    {
+                                        ui.label(RichText::new("WARN ").color(WARM_COLOR));
+                                        ui.label(warning);
+                                        if ui.button("🗙").clicked() {
+                                            clear_toast.send(ClearToastMessage::warn(index))
+                                        }
+                                        ui.end_row();
+                                    }
+                                })
+                            });
+                    }
+                    if ui
+                        .button(
+                            RichText::new(format!("⚠ {}", toasts.toasts_per_kind.warning.len()))
+                                .color(WARM_COLOR),
+                        )
+                        .clicked()
+                    {
+                        menu_state.show_toasts = !menu_state.show_toasts;
+                    }
+                    if ui
+                        .button(
+                            RichText::new(format!("🚫 {}", toasts.toasts_per_kind.error.len()))
+                                .color(ERROR_COLOR),
+                        )
+                        .clicked()
+                    {
+                        menu_state.show_toasts = !menu_state.show_toasts;
+                    }
+
                     if !background_tasks.tasks.is_empty() {
                         //Spinning circle
                         ui.spinner();

--- a/crates/editor_ui/src/menu_toolbars.rs
+++ b/crates/editor_ui/src/menu_toolbars.rs
@@ -462,7 +462,8 @@ pub fn top_menu(
                 }
                 // End Open GLTF
 
-                let distance = ui.available_width() / 2. - 40.;
+                let width = ui.available_width();
+                let distance = width / 2. - 40.;
                 ui.add_space(distance);
                 let play_button = egui::Button::new(to_richtext("▶", &sizing.icon))
                     .fill(SPECIAL_BG_COLOR)
@@ -477,7 +478,8 @@ pub fn top_menu(
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
                     if toasts.has_toasts() {
                         egui::Window::new("Errors")
-                            .anchor(Align2::RIGHT_TOP, egui::Vec2::new(-16., 32.))
+                            .default_size(egui::Vec2::new(80., 32.))
+                            .default_pos(egui::pos2(width, 32.))
                             .movable(true)
                             .resizable(true)
                             .open(&mut menu_state.show_toasts)

--- a/crates/editor_ui/src/meshless_visualizer.rs
+++ b/crates/editor_ui/src/meshless_visualizer.rs
@@ -17,7 +17,10 @@ use space_prefab::editor_registry::EditorRegistryExt;
 use space_shared::*;
 
 use crate::LAST_RENDER_LAYER;
-use space_editor_core::selected::Selected;
+use space_editor_core::{
+    selected::Selected,
+    toast::{ToastKind, ToastMessage},
+};
 
 #[derive(Default)]
 pub struct MeshlessVisualizerPlugin;
@@ -38,6 +41,10 @@ impl Plugin for MeshlessVisualizerPlugin {
                 "icons.ron",
             ]))
         } else {
+            app.world.send_event(ToastMessage::new(
+                "Failed to dynamic load assets. Loading defaults from memory",
+                ToastKind::Error,
+            ));
             error!("Failed to dynamic load assets. Loading defaults from memory");
             app.add_systems(OnEnter(EditorState::Editor), register_assets)
                 .add_systems(

--- a/crates/editor_ui/src/mouse_check.rs
+++ b/crates/editor_ui/src/mouse_check.rs
@@ -1,5 +1,6 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui_next::EguiContexts;
+use space_editor_core::toast::{ToastKind, ToastMessage};
 
 #[derive(Default)]
 pub struct MouseCheck;
@@ -28,12 +29,17 @@ impl Default for PointerContextCheck {
 }
 
 pub fn initialize_mouse_context(
+    mut toast: EventWriter<ToastMessage>,
     mut pointer_ctx: ResMut<PointerContextCheck>,
     window_q: Query<Entity, With<PrimaryWindow>>,
 ) {
     if let Ok(window_id) = window_q.get_single() {
         pointer_ctx.primary_window = Some(window_id);
     } else {
+        toast.send(ToastMessage::new(
+            "Could not get Primary Window",
+            ToastKind::Error,
+        ));
         error!("could not get Primary Window");
     }
 }


### PR DESCRIPTION
<img width="776" alt="Captura de Tela 2024-02-28 às 7 54 50 PM" src="https://github.com/rewin123/space_editor/assets/14813660/4a1e5851-3550-4161-81f5-81694ce3c3bf">

![image](https://github.com/rewin123/space_editor/assets/14813660/8dc9c073-3a81-4e87-96cd-9c44d810f871)

Adds toasts of type:
- info
- warning
- success 
- error

Just need to add:

```rust
fn system_with_toast(
   // ...
  mut toasts: EventWriter<ToastMessage>,
) {
  // ...
  toasts.send_event(ToastMessage::new(
     &format!("Despawning {entity:?}"),
     egui_toast::ToastKind::Warning,
  ));
}
```