### PR TITLE
Fix back in time button and adds 2d meshes

### DIFF
--- a/assets/scenes/cube.scn.ron
+++ b/assets/scenes/cube.scn.ron
@@ -49,7 +49,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 1.0,
           h: 1.0,
           d: 1.0,

--- a/assets/scenes/cubes_camera_test.scn.ron
+++ b/assets/scenes/cubes_camera_test.scn.ron
@@ -105,7 +105,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 1.0,
           h: 1.0,
           d: 1.0,
@@ -165,7 +165,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 1.0,
           h: 1.0,
           d: 1.0,
@@ -225,7 +225,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 1.0,
           h: 1.0,
           d: 1.0,
@@ -289,7 +289,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Plane((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Plane((
           size: 1.0,
           subdivisions: 0,
         )),

--- a/assets/scenes/level.scn.ron
+++ b/assets/scenes/level.scn.ron
@@ -53,7 +53,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -146,7 +146,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -239,7 +239,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -332,7 +332,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -425,7 +425,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -518,7 +518,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 10.0,
           h: 1.0,
           d: 10.0,
@@ -611,7 +611,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Cube(1.0),
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Cube(1.0),
         "space_prefab::save::ChildrenPrefab": ([
           4294967310,
         ]),
@@ -759,7 +759,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.5,

--- a/assets/scenes/level_test.scn.ron
+++ b/assets/scenes/level_test.scn.ron
@@ -53,7 +53,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -146,7 +146,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -239,7 +239,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -328,7 +328,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,
@@ -387,7 +387,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -551,7 +551,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.5,
@@ -610,7 +610,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -778,7 +778,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -871,7 +871,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -964,7 +964,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -1053,7 +1053,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,
@@ -1112,7 +1112,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -1205,7 +1205,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Cube(1.0),
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Cube(1.0),
         "space_prefab::save::ChildrenPrefab": ([
           9,
           12,

--- a/assets/scenes/load_test.scn.ron
+++ b/assets/scenes/load_test.scn.ron
@@ -1,31 +1,87 @@
 (
   resources: {},
   entities: {
-    12884901894: (
+    4294967305: (
+      components: {
+        "bevy_transform::components::transform::Transform": (
+          translation: (
+            x: 0.58761054,
+            y: 12.395405,
+            z: 20.287153,
+          ),
+          rotation: (
+            x: -0.22300434,
+            y: 0.0,
+            z: 0.0,
+            w: 0.97481745,
+          ),
+          scale: (
+            x: 1.0,
+            y: 0.9999998,
+            z: 0.9999998,
+          ),
+        ),
+        "bevy_core::name::Name": (
+          hash: 2354191466762052662,
+          name: "Camera3d",
+        ),
+        "bevy_render::view::visibility::Visibility": Inherited,
+        "bevy_render::camera::camera::Camera": (
+          viewport: None,
+          order: 0,
+          is_active: false,
+          hdr: false,
+          msaa_writeback: true,
+          clear_color: Default,
+        ),
+        "bevy_core_pipeline::core_3d::camera_3d::Camera3d": (
+          depth_load_op: Clear(0.0),
+          depth_texture_usages: (16),
+          screen_space_specular_transmission_steps: 1,
+          screen_space_specular_transmission_quality: Medium,
+        ),
+        "bevy_render::camera::projection::Projection": Perspective((
+          fov: 0.7853982,
+          aspect_ratio: 1.7777778,
+          near: 0.1,
+          far: 1000.0,
+        )),
+        "space_prefab::component::camera::CameraPlay": (),
+        "space_prefab::save::ChildrenPrefab": ([
+          4294967306,
+        ]),
+      },
+    ),
+    4294967308: (
       components: {
         "bevy_transform::components::transform::Transform": (
           translation: (
             x: 0.0,
-            y: 6.4985228,
-            z: 0.0,
+            y: 0.0,
+            z: -2.5538225,
           ),
-          rotation: (x: 0.0, y: 0.0, z: 0.53212, w: 0.84666896),
+          rotation: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 1.0,
+          ),
           scale: (
-            x: 1.0000002,
-            y: 1.0000002,
-            z: 1.0,
+            x: 10.0,
+            y: 1.0,
+            z: 10.0,
           ),
         ),
         "bevy_core::name::Name": (
-          hash: 6842208394028604627,
-          name: "Cube",
+          hash: 14470916567386369765,
+          name: "Plane",
         ),
-        "bevy_render::view::visibility::Visibility": Inherited,
+        "bevy_render::view::visibility::Visibility": Visible,
         "space_prefab::component::material::MaterialPrefab": (
           base_color: Rgba(
-            red: 0.5529412,
-            green: 0.5529412,
-            blue: 0.5529412,
+            red: 0.105882354,
+            green: 0.40784314,
+            blue: 0.30980393,
             alpha: 1.0,
           ),
           base_color_texture: "",
@@ -53,14 +109,32 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
-          w: 10.0,
-          h: 1.0,
-          d: 10.0,
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Plane((
+          normal: ((0.0, 1.0, 0.0)),
+          transform: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          ),
         )),
-        "bevy_xpbd_plugin::collider::ColliderPrefab": FromPrefabMesh,
-        "bevy_xpbd_plugin::registry::RigidBodyPrefab": Dynamic,
-        "bevy_xpbd_3d::components::mass_properties::Mass": (509.0),
+        "space_bevy_xpbd_plugin::collider::ColliderPrefab": Primitive(
+          pos: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          ),
+          rot: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          ),
+          primitive: Cuboid((
+            x: 2.0,
+            y: 0.1,
+            z: 2.0,
+          )),
+        ),
+        "bevy_xpbd_3d::components::mass_properties::Mass": (40.0),
         "bevy_xpbd_3d::components::Friction": (
           dynamic_coefficient: 0.3,
           static_coefficient: 0.3,
@@ -72,19 +146,19 @@
         ),
         "bevy_xpbd_3d::components::mass_properties::Inertia": ((
           x_axis: (
-            x: 4209.834,
+            x: 1333.1997,
             y: 0.0,
             z: 0.0,
           ),
           y_axis: (
             x: 0.0,
-            y: 8417.333,
+            y: 2666.5007,
             z: 0.0,
           ),
           z_axis: (
             x: 0.0,
             y: 0.0,
-            z: 4292.334,
+            z: 1333.1997,
           ),
         )),
         "bevy_xpbd_3d::components::mass_properties::CenterOfMass": ((
@@ -94,15 +168,20 @@
         )),
       },
     ),
-    12884901895: (
+    4294967309: (
       components: {
         "bevy_transform::components::transform::Transform": (
           translation: (
             x: 0.0,
-            y: 0.3266425,
+            y: 9.199398,
             z: 0.0,
           ),
-          rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0),
+          rotation: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 1.0,
+          ),
           scale: (
             x: 1.0,
             y: 1.0,
@@ -110,15 +189,15 @@
           ),
         ),
         "bevy_core::name::Name": (
-          hash: 6842208394028604627,
-          name: "Cube",
+          hash: 1942601542757191479,
+          name: "Box",
         ),
-        "bevy_render::view::visibility::Visibility": Inherited,
+        "bevy_render::view::visibility::Visibility": Visible,
         "space_prefab::component::material::MaterialPrefab": (
           base_color: Rgba(
-            red: 0.5529412,
-            green: 0.5529412,
-            blue: 0.5529412,
+            red: 1.0,
+            green: 0.0,
+            blue: 0.0,
             alpha: 1.0,
           ),
           base_color_texture: "",
@@ -147,13 +226,29 @@
           max_parallax_layer_count: 16.0,
         ),
         "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
-          w: 10.0,
+          w: 1.0,
           h: 1.0,
-          d: 10.0,
+          d: 1.0,
         )),
-        "bevy_xpbd_plugin::collider::ColliderPrefab": FromPrefabMesh,
-        "bevy_xpbd_plugin::registry::RigidBodyPrefab": Static,
-        "bevy_xpbd_3d::components::mass_properties::Mass": (409.0),
+        "space_bevy_xpbd_plugin::collider::ColliderPrefab": Primitive(
+          pos: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          ),
+          rot: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          ),
+          primitive: Cuboid((
+            x: 1.0,
+            y: 1.0,
+            z: 1.0,
+          )),
+        ),
+        "space_bevy_xpbd_plugin::registry::RigidBodyPrefab": Dynamic,
+        "bevy_xpbd_3d::components::mass_properties::Mass": (1.0),
         "bevy_xpbd_3d::components::Friction": (
           dynamic_coefficient: 0.3,
           static_coefficient: 0.3,
@@ -165,19 +260,19 @@
         ),
         "bevy_xpbd_3d::components::mass_properties::Inertia": ((
           x_axis: (
-            x: 3368.167,
+            x: 0.0,
             y: 0.0,
             z: 0.0,
           ),
           y_axis: (
             x: 0.0,
-            y: 6750.6665,
+            y: 0.0,
             z: 0.0,
           ),
           z_axis: (
             x: 0.0,
             y: 0.0,
-            z: 3450.667,
+            z: 0.0,
           ),
         )),
         "bevy_xpbd_3d::components::mass_properties::CenterOfMass": ((

--- a/assets/scenes/physics_loading_test.scn.ron
+++ b/assets/scenes/physics_loading_test.scn.ron
@@ -53,7 +53,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Cube(1.0),
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Cube(1.0),
         "space_prefab::save::ChildrenPrefab": ([
           4294967318,
           4294967317,
@@ -143,7 +143,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,
@@ -202,7 +202,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -291,7 +291,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.5,
@@ -346,7 +346,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,

--- a/assets/scenes/physics_object.scn.ron
+++ b/assets/scenes/physics_object.scn.ron
@@ -53,7 +53,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -146,7 +146,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -239,7 +239,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -328,7 +328,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,
@@ -387,7 +387,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -551,7 +551,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.5,
@@ -610,7 +610,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -778,7 +778,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -871,7 +871,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -964,7 +964,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -1053,7 +1053,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 0.2,
           h: 0.2,
           d: 0.2,
@@ -1112,7 +1112,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Box((
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Box((
           w: 5.0,
           h: 1.0,
           d: 5.0,
@@ -1205,7 +1205,7 @@
           parallax_mapping_method: Occlusion,
           max_parallax_layer_count: 16.0,
         ),
-        "space_prefab::component::shape::MeshPrimitivePrefab": Cube(1.0),
+        "space_prefab::component::shape::MeshPrimitive3dPrefab": Cube(1.0),
         "space_prefab::save::ChildrenPrefab": ([
           10,
           13,

--- a/assets/scenes/test_open_gltf.scn.ron
+++ b/assets/scenes/test_open_gltf.scn.ron
@@ -50,7 +50,7 @@
           max_parallax_layer_count: 16.0,
         ),
         "space_prefab::component::AssetMesh": (
-          path: "low_poly_fighter_2.gltf#Mesh1/Primitive0",
+          path: "models/low_poly_fighter_2.gltf#Mesh1/Primitive0",
         ),
         "space_prefab::save::ChildrenPrefab": ([
           4294967305,
@@ -74,10 +74,10 @@
         ),
         "bevy_render::view::visibility::Visibility": Inherited,
         "space_prefab::component::AssetMesh": (
-          path: "low_poly_fighter_2.gltf#Mesh0/Primitive0",
+          path: "models/low_poly_fighter_2.gltf#Mesh0/Primitive0",
         ),
         "space_prefab::component::AssetMaterial": (
-          path: "low_poly_fighter_2.gltf#Material0",
+          path: "models/low_poly_fighter_2.gltf#Material0",
         ),
       },
     ),
@@ -130,7 +130,7 @@
           max_parallax_layer_count: 16.0,
         ),
         "space_prefab::component::AssetMesh": (
-          path: "low_poly_fighter_2.gltf#Mesh1/Primitive0",
+          path: "models/low_poly_fighter_2.gltf#Mesh1/Primitive0",
         ),
         "space_prefab::save::ChildrenPrefab": ([
           4294967307,
@@ -154,10 +154,10 @@
         ),
         "bevy_render::view::visibility::Visibility": Inherited,
         "space_prefab::component::AssetMesh": (
-          path: "low_poly_fighter_2.gltf#Mesh0/Primitive0",
+          path: "models/low_poly_fighter_2.gltf#Mesh0/Primitive0",
         ),
         "space_prefab::component::AssetMaterial": (
-          path: "low_poly_fighter_2.gltf#Material0",
+          path: "models/low_poly_fighter_2.gltf#Material0",
         ),
       },
     ),
@@ -210,7 +210,7 @@
           max_parallax_layer_count: 16.0,
         ),
         "space_prefab::component::AssetMesh": (
-          path: "low_poly_fighter_2.gltf#Mesh2/Primitive0",
+          path: "models/low_poly_fighter_2.gltf#Mesh2/Primitive0",
         ),
         "space_prefab::save::ChildrenPrefab": ([
           4294967306,

--- a/crates/editor_core/src/toast.rs
+++ b/crates/editor_core/src/toast.rs
@@ -131,7 +131,9 @@ fn show_toast(
     mut storage: ResMut<ToastStorage>,
     mut ctxs: Query<&mut EguiContext, With<PrimaryWindow>>,
 ) {
-    let mut ctx = ctxs.single_mut();
+    let Ok(mut ctx) = ctxs.get_single_mut() else {
+        return;
+    };
     storage.toasts.show(ctx.get_mut());
 }
 

--- a/crates/editor_core/src/toast.rs
+++ b/crates/editor_core/src/toast.rs
@@ -240,4 +240,23 @@ mod tests {
         let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
         assert!(!storage.has_toasts());
     }
+
+    #[test]
+    fn empty_storage_for_info_toasts() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, ToastBasePlugin));
+
+        app.update();
+        assert!(!app
+            .world
+            .get_resource::<ToastStorage>()
+            .unwrap()
+            .has_toasts());
+        app.world
+            .send_event(ToastMessage::new("Test message", ToastKind::Info));
+        app.update();
+
+        let storage: &ToastStorage = app.world.get_resource::<ToastStorage>().unwrap();
+        assert!(!storage.has_toasts());
+    }
 }

--- a/crates/editor_ui/src/camera_plugin.rs
+++ b/crates/editor_ui/src/camera_plugin.rs
@@ -25,6 +25,8 @@ impl Plugin for EditorDefaultCameraPlugin {
                 .before(update_pan_orbit)
                 .in_set(EditorSet::Editor),
         );
+        app.add_systems(OnEnter(EditorState::GamePrepare), reset_play_camera_state);
+        app.add_systems(OnEnter(EditorState::Editor), reset_editor_camera_state);
     }
 }
 
@@ -32,9 +34,20 @@ impl Plugin for EditorDefaultCameraPlugin {
 #[derive(Resource, Default)]
 pub struct EditorCameraEnabled(pub bool);
 
+impl From<bool> for EditorCameraEnabled {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
 /// This system executes before all UI systems and is used to enable pan orbit camera on frame start
 pub fn reset_editor_camera_state(mut state: ResMut<EditorCameraEnabled>) {
-    *state = EditorCameraEnabled(true);
+    *state = true.into();
+}
+
+/// This system executes before all UI systems and is used to enable pan orbit camera on frame start
+pub fn reset_play_camera_state(mut state: ResMut<EditorCameraEnabled>) {
+    *state = false.into();
 }
 
 /// This system executes after all UI systems and is used to set pan orbit camera state.

--- a/crates/editor_ui/src/camera_view.rs
+++ b/crates/editor_ui/src/camera_view.rs
@@ -96,6 +96,7 @@ impl EditorTab for CameraViewTab {
                             TemporalJitter::default(),
                             Name::new("Camera for Camera view tab"),
                             DisableCameraSkip,
+                            EditorCameraMarker,
                             ViewCamera,
                         ))
                         .id(),
@@ -108,6 +109,7 @@ impl EditorTab for CameraViewTab {
                             RenderLayers::layer(0),
                             Name::new("Camera for Camera view tab"),
                             DisableCameraSkip,
+                            EditorCameraMarker,
                             ViewCamera,
                         ))
                         .id(),

--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -2,7 +2,10 @@
 use std::sync::Arc;
 
 use bevy::{ecs::query::QueryFilter, prelude::*, utils::HashMap};
-use bevy_egui::{egui::collapsing_header::CollapsingState, *};
+use bevy_egui::{
+    egui::{collapsing_header::CollapsingState, TextEdit},
+    *,
+};
 use space_editor_core::prelude::*;
 use space_prefab::{component::SceneAutoChild, editor_registry::EditorRegistry};
 use space_undo::{AddedEntity, NewChange, RemovedEntity, UndoSet};
@@ -77,7 +80,13 @@ pub fn show_hierarchy(
     };
     all.sort_by_key(|a| a.0);
     let ui = &mut ui.0;
-    ui.text_edit_singleline(&mut state.entity_filter);
+    ui.horizontal(|ui| {
+        let width = ui.available_width() * 0.85;
+        ui.add(TextEdit::singleline(&mut state.entity_filter).desired_width(width));
+        if ui.button("🗑").on_hover_text("Clear test").clicked() {
+            state.entity_filter.clear();
+        }
+    });
     ui.spacing();
     let lower_filter = state.entity_filter.to_lowercase();
 

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -14,7 +14,7 @@ use bevy::{
     utils::HashMap,
 };
 
-use bevy_egui::*;
+use bevy_egui::{egui::TextEdit, *};
 
 use space_editor_core::prelude::*;
 use space_prefab::{component::EntityLink, editor_registry::EditorRegistry};
@@ -212,7 +212,13 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World, open_components: &mut HashM
             }
             ui.heading(&name);
             let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
-            ui.text_edit_singleline(&mut state.component_add_filter);
+            ui.horizontal(|ui| {
+                let width = ui.available_width() * 0.85;
+                ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                if ui.button("🗑").on_hover_text("Clear test").clicked() {
+                    state.component_add_filter.clear();
+                }
+            });
             let lower_filter = state.component_add_filter.to_lowercase();
             let e_id = e.id().index();
             ui.label("Components:");
@@ -317,7 +323,14 @@ pub fn inspect(ui: &mut egui::Ui, world: &mut World, open_components: &mut HashM
         .default_pos(components_area.inner_rect.center_bottom())
         .show(ui.ctx(), |ui: &mut egui::Ui| {
             let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
-            ui.text_edit_singleline(&mut state.component_add_filter);
+            ui.horizontal(|ui| {
+                let width = ui.available_width() * 0.85;
+                ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                // ui.text_edit_singleline(&mut state.component_add_filter);
+                if ui.button("🗑").on_hover_text("Clear test").clicked() {
+                    state.component_add_filter.clear();
+                }
+            });
             let lower_filter = state.component_add_filter.to_lowercase();
             egui::Grid::new("Component grid").show(ui, |ui| {
                 let _counter = 0;

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -161,7 +161,13 @@ impl EditorTab for InspectorTab {
                 }
                 ui.heading(&name);
                 let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
-                ui.text_edit_singleline(&mut state.component_add_filter);
+                ui.horizontal(|ui| {
+                    let width = ui.available_width() * 0.85;
+                    ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                    if ui.button("🗑").on_hover_text("Clear test").clicked() {
+                        state.component_add_filter.clear();
+                    }
+                });
                 let lower_filter = state.component_add_filter.to_lowercase();
                 let e_id = e.id().index();
                 ui.label("Components:");
@@ -272,7 +278,13 @@ impl EditorTab for InspectorTab {
             .default_pos(components_area.inner_rect.center_bottom())
             .show(ui.ctx(), |ui: &mut egui::Ui| {
                 let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
-                ui.text_edit_singleline(&mut state.component_add_filter);
+                ui.horizontal(|ui| {
+                    let width = ui.available_width() * 0.85;
+                    ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                    if ui.button("🗑").on_hover_text("Clear test").clicked() {
+                        state.component_add_filter.clear();
+                    }
+                });
                 let lower_filter = state.component_add_filter.to_lowercase();
                 egui::Grid::new("Component grid").show(ui, |ui| {
                     let _counter = 0;

--- a/crates/editor_ui/src/inspector/mod.rs
+++ b/crates/editor_ui/src/inspector/mod.rs
@@ -163,7 +163,9 @@ impl EditorTab for InspectorTab {
                 let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
                 ui.horizontal(|ui| {
                     let width = ui.available_width() * 0.85;
-                    ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                    ui.add(
+                        TextEdit::singleline(&mut state.component_add_filter).desired_width(width),
+                    );
                     if ui.button("🗑").on_hover_text("Clear test").clicked() {
                         state.component_add_filter.clear();
                     }
@@ -280,7 +282,9 @@ impl EditorTab for InspectorTab {
                 let mut state = unsafe { cell.get_resource_mut::<FilterComponentState>().unwrap() };
                 ui.horizontal(|ui| {
                     let width = ui.available_width() * 0.85;
-                    ui.add(TextEdit::singleline(&mut state.component_add_filter).desired_width(width));
+                    ui.add(
+                        TextEdit::singleline(&mut state.component_add_filter).desired_width(width),
+                    );
                     if ui.button("🗑").on_hover_text("Clear test").clicked() {
                         state.component_add_filter.clear();
                     }

--- a/crates/editor_ui/src/lib.rs
+++ b/crates/editor_ui/src/lib.rs
@@ -93,6 +93,7 @@ use space_editor_core::toast::ToastUiPlugin;
 use space_prefab::prelude::*;
 use space_shared::{
     ext::bevy_inspector_egui::{quick::WorldInspectorPlugin, DefaultInspectorConfigPlugin},
+    toast::ToastMessage,
     EditorCameraMarker, EditorSet, EditorState, PrefabMarker, PrefabMemoryCache,
 };
 use space_undo::{SyncUndoMarkersPlugin, UndoPlugin, UndoSet};
@@ -250,7 +251,14 @@ type AutoAddQueryFilter = (
     Changed<Handle<Mesh>>,
 );
 
-fn save_prefab_before_play(mut editor_events: EventWriter<space_shared::EditorEvent>) {
+fn save_prefab_before_play(
+    mut editor_events: EventWriter<space_shared::EditorEvent>,
+    mut toast: EventWriter<ToastMessage>,
+) {
+    toast.send(ToastMessage::new(
+        "Preparing prefab to save for playmode",
+        space_shared::toast::ToastKind::Info,
+    ));
     editor_events.send(space_shared::EditorEvent::Save(
         space_shared::EditorPrefabPath::MemoryCache,
     ));

--- a/crates/editor_ui/src/menu_toolbars.rs
+++ b/crates/editor_ui/src/menu_toolbars.rs
@@ -30,6 +30,7 @@ impl Plugin for BottomMenuPlugin {
         if !app.is_plugin_added::<PrefabPlugin>() {
             app.add_plugins(PrefabPlugin);
         }
+
         app.init_resource::<EditorLoader>();
         app.init_resource::<MenuToolbarState>();
 
@@ -79,6 +80,7 @@ fn in_game_menu(
             let layout = egui::Layout::left_to_right(Align::Center).with_main_align(Align::Center);
             ui.with_layout(layout, |ui| {
                 ui.label(format!("FPS: {:04.0}", 1.0 / *smoothed_dt));
+
                 let distance = ui.available_width() / 2. - 64.;
                 ui.add_space(distance);
                 let button = if time.is_paused() {
@@ -86,9 +88,6 @@ fn in_game_menu(
                 } else {
                     to_richtext("⏸", &sizing.icon)
                 };
-                if ui.button(to_richtext("⏮", &sizing.icon)).clicked() {
-                    time.advance_by(frame_duration.mul_f32(-1.));
-                }
                 if ui.button(button).clicked() {
                     if time.is_paused() {
                         time.unpause();
@@ -99,7 +98,11 @@ fn in_game_menu(
                 if ui.button(to_richtext("⏹", &sizing.icon)).clicked() {
                     state.set(EditorState::Editor);
                 }
-                if ui.button(to_richtext("⏭", &sizing.icon)).clicked() {
+                if ui
+                    .button(to_richtext("⏭", &sizing.icon))
+                    .on_hover_text("Step by delta time")
+                    .clicked()
+                {
                     time.advance_by(frame_duration);
                 }
 

--- a/crates/editor_ui/src/selection.rs
+++ b/crates/editor_ui/src/selection.rs
@@ -100,8 +100,7 @@ pub fn delete_selected(
 ) {
     let shift = keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
     let ctrl = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
-    let delete =
-        keyboard.just_pressed(KeyCode::Backspace) || keyboard.just_pressed(KeyCode::Delete);
+    let delete = keyboard.any_just_pressed([KeyCode::Backspace, KeyCode::Delete]);
 
     if ctrl && shift && delete {
         for entity in query.iter() {

--- a/crates/editor_ui/src/settings.rs
+++ b/crates/editor_ui/src/settings.rs
@@ -47,7 +47,7 @@ impl Plugin for SettingsWindowPlugin {
     }
 }
 
-#[derive(Default, Reflect, PartialEq, Eq, Clone)]
+#[derive(Default, Reflect, PartialEq, Eq, Clone, Debug)]
 pub enum GameMode {
     Game2D,
     #[default]
@@ -63,7 +63,7 @@ impl ToString for GameMode {
     }
 }
 
-#[derive(Default, Resource, Reflect, Clone)]
+#[derive(Default, Resource, Reflect, Clone, Debug)]
 #[reflect(Resource)]
 pub struct GameModeSettings {
     pub mode: GameMode,
@@ -191,9 +191,8 @@ impl EditorTab for SettingsWindow {
     fn ui(&mut self, ui: &mut egui::Ui, commands: &mut Commands, world: &mut World) {
         let game_mode_setting = &world.resource::<GameModeSettings>();
         if let Some(new_game_mode) = game_mode_setting.ui(ui) {
-            let game_mode_setting: &mut GameModeSettings =
-                &mut world.resource_mut::<GameModeSettings>();
-            *game_mode_setting = new_game_mode;
+            info!("Game Mode changed: {:?}", new_game_mode);
+            *world.resource_mut::<GameModeSettings>() = new_game_mode;
         }
 
         ui.heading("Undo");

--- a/crates/editor_ui/src/tools/gizmo.rs
+++ b/crates/editor_ui/src/tools/gizmo.rs
@@ -130,7 +130,10 @@ impl EditorTool for GizmoTool {
             }
         }
 
-        if ui.input(|s| s.key_pressed(Key::Delete) || input.just_pressed(GizmoHotkey::Delete)) {
+        if ui.input(|s| {
+            input.just_pressed(GizmoHotkey::Delete)
+                || (s.modifiers.shift && s.modifiers.ctrl && s.key_pressed(Key::Delete))
+        }) {
             del = true;
         }
 

--- a/crates/editor_ui/src/ui_registration.rs
+++ b/crates/editor_ui/src/ui_registration.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use bevy::ecs::system::EntityCommands;
+use bevy::{ecs::system::EntityCommands, render::camera::CameraRenderGraph};
 
 use space_prefab::{component::*, ext::*};
 use space_shared::{LightAreaToggle, PrefabMarker};
@@ -122,7 +122,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Cube(1.0),
             Name::new("Cube".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -132,7 +132,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Box(BoxPrefab::default()),
             Name::new("Box".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -142,7 +142,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Sphere(SpherePrefab::default()),
             Name::new("UVSphere".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -152,7 +152,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Quad(QuadPrefab::default()),
             Name::new("Rectagle".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -162,7 +162,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Capsule(CapsulePrefab::default()),
             Name::new("Capsule"),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -172,7 +172,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Circle(CirclePrefab::default()),
             Name::new("Circle".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -182,7 +182,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Cylinder(CylinderPrefab::default()),
             Name::new("Cylinder".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -192,7 +192,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Plane(Plane3dPrefab::default()),
             Name::new("Plane".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -202,7 +202,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::PlaneMultipoint(PlaneMultiPointPrefab::default()),
             Name::new("Plane Multipoint".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -212,7 +212,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::RegularPolygon(RegularPolygonPrefab::default()),
             Name::new("Regular Polygon".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
     app.editor_bundle(
@@ -222,7 +222,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive3dPrefab::Torus(TorusPrefab::default()),
             Name::new("Torus".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -233,7 +233,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::Rectagle(QuadPrefab::default()),
             Name::new("2D Quad".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -244,7 +244,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::Circle(CirclePrefab::default()),
             Name::new("2D Circle".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -255,7 +255,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::Ellipse(EllipsePrefab::default()),
             Name::new("2D Ellipse".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -266,7 +266,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::Triangle(TrianglePrefab::default()),
             Name::new("2D Triangle".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -277,7 +277,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::Triangle(TrianglePrefab::default()),
             Name::new("2D Triangle".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -288,7 +288,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             MeshPrimitive2dPrefab::RegularPolygon(RegularPolygonPrefab::default()),
             Name::new("2D Regular Polygon".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
         ),
     );
 
@@ -299,7 +299,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             Camera3d::default(),
             Name::new("Camera3d".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
             CameraPlay::default(),
         ),
     );
@@ -311,8 +311,9 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
             Camera2d {},
             Name::new("Camera2d".to_string()),
             Transform::default(),
-            Visibility::default(),
+            VisibilityBundle::default(),
             CameraPlay::default(),
+            CameraRenderGraph::new(bevy::core_pipeline::core_2d::graph::Core2d),
         ),
     );
 

--- a/crates/editor_ui/src/ui_registration.rs
+++ b/crates/editor_ui/src/ui_registration.rs
@@ -86,6 +86,7 @@ pub fn register_light_editor_bundles(app: &mut App) {
             Name::new("Point light"),
             PointLight::default(),
             LightAreaToggle::default(),
+            LightPlay::default(),
         ),
     );
 
@@ -96,6 +97,7 @@ pub fn register_light_editor_bundles(app: &mut App) {
             Name::new("Directional light"),
             DirectionalLight::default(),
             LightAreaToggle::default(),
+            LightPlay::default(),
         ),
     );
 
@@ -106,6 +108,7 @@ pub fn register_light_editor_bundles(app: &mut App) {
             Name::new("Spot light"),
             SpotLight::default(),
             LightAreaToggle::default(),
+            LightPlay::default(),
         ),
     );
 }

--- a/crates/editor_ui/src/ui_registration.rs
+++ b/crates/editor_ui/src/ui_registration.rs
@@ -119,6 +119,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Cube",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Cube(1.0),
             Name::new("Cube".to_string()),
             Transform::default(),
@@ -129,6 +130,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Box",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Box(BoxPrefab::default()),
             Name::new("Box".to_string()),
             Transform::default(),
@@ -139,6 +141,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Sphere",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Sphere(SpherePrefab::default()),
             Name::new("UVSphere".to_string()),
             Transform::default(),
@@ -149,6 +152,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Rectagle",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Quad(QuadPrefab::default()),
             Name::new("Rectagle".to_string()),
             Transform::default(),
@@ -159,6 +163,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Capsule",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Capsule(CapsulePrefab::default()),
             Name::new("Capsule"),
             Transform::default(),
@@ -169,6 +174,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Circle",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Circle(CirclePrefab::default()),
             Name::new("Circle".to_string()),
             Transform::default(),
@@ -179,6 +185,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Cylinder",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Cylinder(CylinderPrefab::default()),
             Name::new("Cylinder".to_string()),
             Transform::default(),
@@ -189,6 +196,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Plane",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Plane(Plane3dPrefab::default()),
             Name::new("Plane".to_string()),
             Transform::default(),
@@ -199,6 +207,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Plane Multipoint",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::PlaneMultipoint(PlaneMultiPointPrefab::default()),
             Name::new("Plane Multipoint".to_string()),
             Transform::default(),
@@ -209,6 +218,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Regular Polygon",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::RegularPolygon(RegularPolygonPrefab::default()),
             Name::new("Regular Polygon".to_string()),
             Transform::default(),
@@ -219,6 +229,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "3D Torus",
         (
+            PrefabMarker,
             MeshPrimitive3dPrefab::Torus(TorusPrefab::default()),
             Name::new("Torus".to_string()),
             Transform::default(),
@@ -230,6 +241,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Rectagle",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::Rectagle(QuadPrefab::default()),
             Name::new("2D Quad".to_string()),
             Transform::default(),
@@ -241,6 +253,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Circle",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::Circle(CirclePrefab::default()),
             Name::new("2D Circle".to_string()),
             Transform::default(),
@@ -252,6 +265,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Ellipse",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::Ellipse(EllipsePrefab::default()),
             Name::new("2D Ellipse".to_string()),
             Transform::default(),
@@ -263,6 +277,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Triangle",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::Triangle(TrianglePrefab::default()),
             Name::new("2D Triangle".to_string()),
             Transform::default(),
@@ -274,6 +289,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Triangle",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::Triangle(TrianglePrefab::default()),
             Name::new("2D Triangle".to_string()),
             Transform::default(),
@@ -285,6 +301,7 @@ pub fn register_mesh_editor_bundles(app: &mut App) {
         "Mesh",
         "2D Regular Polygon",
         (
+            PrefabMarker,
             MeshPrimitive2dPrefab::RegularPolygon(RegularPolygonPrefab::default()),
             Name::new("2D Regular Polygon".to_string()),
             Transform::default(),

--- a/crates/prefab/src/component/camera.rs
+++ b/crates/prefab/src/component/camera.rs
@@ -5,3 +5,9 @@ use crate::ext::*;
 #[derive(Component, Clone, Default, Reflect)]
 #[reflect(Default, Component)]
 pub struct CameraPlay {}
+
+/// Play Mode only Light tag/marker
+#[cfg(not(tarpaulin_include))]
+#[derive(Component, Clone, Default, Reflect)]
+#[reflect(Default, Component)]
+pub struct LightPlay {}

--- a/crates/prefab/src/component/shape.rs
+++ b/crates/prefab/src/component/shape.rs
@@ -52,7 +52,7 @@ impl Default for MeshPrimitive2dPrefab {
 }
 
 impl MeshPrimitive3dPrefab {
-    /// Convert [`MeshPrimitivePrefab`] to bevy [`Mesh`]
+    /// Convert [`MeshPrimitive3DPrefab`] to bevy [`Mesh`]
     pub fn to_mesh(&self) -> Mesh {
         match self {
             Self::Cube(s) => Mesh::from(math_shapes::Cuboid::new(*s, *s, *s)),

--- a/crates/prefab/src/component/shape.rs
+++ b/crates/prefab/src/component/shape.rs
@@ -140,7 +140,9 @@ pub struct QuadPrefab {
 
 impl Default for QuadPrefab {
     fn default() -> Self {
-        Self { size: Vec2::ONE }
+        Self {
+            size: Vec2::ONE * 10.,
+        }
     }
 }
 
@@ -189,7 +191,9 @@ pub struct CirclePrefab {
 impl Default for CirclePrefab {
     fn default() -> Self {
         let def = math_shapes::Circle::default();
-        Self { r: def.radius }
+        Self {
+            r: def.radius * 10.,
+        }
     }
 }
 
@@ -211,7 +215,7 @@ impl Default for EllipsePrefab {
     fn default() -> Self {
         let def = math_shapes::Ellipse::default();
         Self {
-            radius_pair: def.half_size,
+            radius_pair: def.half_size * 10.,
         }
     }
 }
@@ -262,8 +266,8 @@ impl Default for Capsule2dPrefab {
     fn default() -> Self {
         let def = math_shapes::Capsule2d::default();
         Self {
-            radius: def.radius,
-            half_length: def.half_length,
+            radius: def.radius * 10.,
+            half_length: def.half_length * 10.,
         }
     }
 }
@@ -317,7 +321,7 @@ impl Default for PlanePrefab {
     fn default() -> Self {
         let def = math_shapes::Rectangle::default();
         Self {
-            size: def.half_size * 2.,
+            size: def.half_size * 2. * 10.,
         }
     }
 }
@@ -418,7 +422,7 @@ impl Default for RegularPolygonPrefab {
     fn default() -> Self {
         let def = math_shapes::RegularPolygon::default();
         Self {
-            circumcircle_radius: def.circumcircle.radius,
+            circumcircle_radius: def.circumcircle.radius * 10.,
             sides: def.sides,
         }
     }

--- a/crates/prefab/src/plugins.rs
+++ b/crates/prefab/src/plugins.rs
@@ -75,7 +75,6 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<Visibility>();
 
         app.editor_registry::<GltfPrefab>();
-        app.editor_relation::<GltfPrefab, PrefabMarker>();
         app.editor_registry::<MaterialPrefab>();
         app.editor_registry::<ColorMaterialPrefab>();
 
@@ -83,13 +82,11 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<SpriteTexture>();
         app.editor_relation::<SpriteTexture, Transform>();
         app.editor_relation::<SpriteTexture, Visibility>();
-        app.editor_relation::<Sprite, PrefabMarker>();
 
         // Spritesheet bundle
         app.editor_registry::<SpritesheetTexture>();
         app.editor_relation::<SpritesheetTexture, Transform>();
         app.editor_relation::<SpritesheetTexture, Visibility>();
-        app.editor_relation::<SpritesheetTexture, PrefabMarker>();
         app.editor_registry::<AnimationIndicesSpriteSheet>();
         app.editor_registry::<AnimationClipName>();
         app.editor_registry::<AvailableAnimationClips>();
@@ -101,13 +98,11 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<MeshPrimitive3dPrefab, Transform>();
         app.editor_relation::<MeshPrimitive3dPrefab, Visibility>();
         app.editor_relation::<MeshPrimitive3dPrefab, MaterialPrefab>();
-        app.editor_relation::<MeshPrimitive3dPrefab, PrefabMarker>();
 
         app.editor_registry::<MeshPrimitive2dPrefab>();
         app.editor_relation::<MeshPrimitive2dPrefab, Transform>();
         app.editor_relation::<MeshPrimitive2dPrefab, Visibility>();
         app.editor_relation::<MeshPrimitive2dPrefab, ColorMaterialPrefab>();
-        app.editor_relation::<MeshPrimitive2dPrefab, PrefabMarker>();
 
         //shape registration
         app.register_type::<SpherePrefab>();
@@ -149,7 +144,6 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<Projection>();
         app.editor_registry::<OrthographicProjection>();
         app.editor_registry::<CameraPlay>();
-        app.editor_relation::<CameraPlay, PrefabMarker>();
 
         app.register_type::<Camera3dDepthTextureUsage>();
         app.register_type::<ScreenSpaceTransmissionQuality>();
@@ -173,7 +167,6 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<PlayerStart, Visibility>();
         app.editor_relation::<PlayerStart, ViewVisibility>();
         app.editor_relation::<PlayerStart, InheritedVisibility>();
-        app.editor_relation::<PlayerStart, PrefabMarker>();
 
         app.editor_relation::<Transform, GlobalTransform>();
 
@@ -201,7 +194,6 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<SpotLight, Visibility>();
 
         app.editor_registry::<LightPlay>();
-        app.editor_relation::<LightPlay, PrefabMarker>();
 
         #[cfg(feature = "editor")]
         app.add_event::<ToastMessage>();

--- a/crates/prefab/src/plugins.rs
+++ b/crates/prefab/src/plugins.rs
@@ -75,6 +75,7 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<Visibility>();
 
         app.editor_registry::<GltfPrefab>();
+        app.editor_relation::<GltfPrefab, PrefabMarker>();
         app.editor_registry::<MaterialPrefab>();
         app.editor_registry::<ColorMaterialPrefab>();
 
@@ -82,11 +83,13 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<SpriteTexture>();
         app.editor_relation::<SpriteTexture, Transform>();
         app.editor_relation::<SpriteTexture, Visibility>();
+        app.editor_relation::<Sprite, PrefabMarker>();
 
         // Spritesheet bundle
         app.editor_registry::<SpritesheetTexture>();
         app.editor_relation::<SpritesheetTexture, Transform>();
         app.editor_relation::<SpritesheetTexture, Visibility>();
+        app.editor_relation::<SpritesheetTexture, PrefabMarker>();
         app.editor_registry::<AnimationIndicesSpriteSheet>();
         app.editor_registry::<AnimationClipName>();
         app.editor_registry::<AvailableAnimationClips>();
@@ -98,11 +101,13 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<MeshPrimitive3dPrefab, Transform>();
         app.editor_relation::<MeshPrimitive3dPrefab, Visibility>();
         app.editor_relation::<MeshPrimitive3dPrefab, MaterialPrefab>();
+        app.editor_relation::<MeshPrimitive3dPrefab, PrefabMarker>();
 
         app.editor_registry::<MeshPrimitive2dPrefab>();
         app.editor_relation::<MeshPrimitive2dPrefab, Transform>();
         app.editor_relation::<MeshPrimitive2dPrefab, Visibility>();
         app.editor_relation::<MeshPrimitive2dPrefab, ColorMaterialPrefab>();
+        app.editor_relation::<MeshPrimitive2dPrefab, PrefabMarker>();
 
         //shape registration
         app.register_type::<SpherePrefab>();
@@ -144,6 +149,7 @@ impl Plugin for BasePrefabPlugin {
         app.editor_registry::<Projection>();
         app.editor_registry::<OrthographicProjection>();
         app.editor_registry::<CameraPlay>();
+        app.editor_relation::<CameraPlay, PrefabMarker>();
 
         app.register_type::<Camera3dDepthTextureUsage>();
         app.register_type::<ScreenSpaceTransmissionQuality>();
@@ -167,9 +173,9 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<PlayerStart, Visibility>();
         app.editor_relation::<PlayerStart, ViewVisibility>();
         app.editor_relation::<PlayerStart, InheritedVisibility>();
+        app.editor_relation::<PlayerStart, PrefabMarker>();
 
         app.editor_relation::<Transform, GlobalTransform>();
-        app.editor_relation::<Transform, PrefabMarker>();
 
         //Light
         app.editor_registry::<LightAreaToggle>();
@@ -193,6 +199,10 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<SpotLight, Frustum>();
         app.editor_relation::<SpotLight, Transform>();
         app.editor_relation::<SpotLight, Visibility>();
+
+        app.editor_registry::<LightPlay>();
+        app.editor_relation::<LightPlay, PrefabMarker>();
+
         #[cfg(feature = "editor")]
         app.add_event::<ToastMessage>();
 

--- a/crates/prefab/src/plugins.rs
+++ b/crates/prefab/src/plugins.rs
@@ -12,6 +12,8 @@ use bevy::{
     },
 };
 use bevy_scene_hook::HookPlugin;
+#[cfg(feature = "editor")]
+use space_shared::toast::ToastMessage;
 use space_shared::{LightAreaToggle, PrefabMarker};
 
 use crate::{
@@ -110,8 +112,13 @@ impl Plugin for BasePrefabPlugin {
         app.register_type::<CirclePrefab>();
         app.register_type::<CylinderPrefab>();
         app.register_type::<PlanePrefab>();
+        app.register_type::<Plane3dPrefab>();
+        app.register_type::<PlaneMultiPointPrefab>();
         app.register_type::<RegularPolygonPrefab>();
         app.register_type::<TorusPrefab>();
+        app.register_type::<EllipsePrefab>();
+        app.register_type::<TrianglePrefab>();
+        app.register_type::<Capsule2dPrefab>();
 
         app.editor_registry::<AssetMesh>();
         app.add_systems(
@@ -162,6 +169,7 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<PlayerStart, InheritedVisibility>();
 
         app.editor_relation::<Transform, GlobalTransform>();
+        app.editor_relation::<Transform, PrefabMarker>();
 
         //Light
         app.editor_registry::<LightAreaToggle>();
@@ -185,6 +193,8 @@ impl Plugin for BasePrefabPlugin {
         app.editor_relation::<SpotLight, Frustum>();
         app.editor_relation::<SpotLight, Transform>();
         app.editor_relation::<SpotLight, Visibility>();
+        #[cfg(feature = "editor")]
+        app.add_event::<ToastMessage>();
 
         app.add_systems(OnEnter(EditorState::Game), spawn_player_start);
 

--- a/crates/prefab/src/spawn_system.rs
+++ b/crates/prefab/src/spawn_system.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy_scene_hook::SceneHook;
-use space_shared::{toast::ToastMessage, PrefabMarker};
+#[cfg(feature = "editor")]
+use space_shared::toast::ToastMessage;
+use space_shared::PrefabMarker;
 
 use super::component::*;
 
@@ -191,10 +193,11 @@ pub fn spawn_player_start(
     mut commands: Commands,
     query: Query<(Entity, &PlayerStart)>,
     asset_server: Res<AssetServer>,
-    mut toast: EventWriter<ToastMessage>,
+    #[cfg(feature = "editor")] mut toast: EventWriter<ToastMessage>,
 ) {
     for (e, prefab) in query.iter() {
         let msg = format!("Spawning player start: {:?} with \"{}\"", e, &prefab.prefab);
+        #[cfg(feature = "editor")]
         toast.send(ToastMessage::new(
             &msg,
             space_shared::toast::ToastKind::Info,

--- a/crates/prefab/src/spawn_system.rs
+++ b/crates/prefab/src/spawn_system.rs
@@ -89,7 +89,7 @@ pub fn sync_2d_mesh(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     for (e, prefab) in query.iter() {
-        let mesh = meshes.add(prefab.to_mesh());
+        let mesh = bevy::sprite::Mesh2dHandle(meshes.add(prefab.to_mesh()));
         commands.entity(e).insert(mesh);
     }
 }

--- a/crates/prefab/src/sub_scene/mod.rs
+++ b/crates/prefab/src/sub_scene/mod.rs
@@ -5,6 +5,7 @@ use bevy::{
     utils::HashSet,
 };
 use serde::de::DeserializeSeed;
+#[cfg(feature = "editor")]
 use space_shared::toast::ToastMessage;
 
 use crate::{
@@ -145,13 +146,14 @@ fn decompress_scene(
     mut commands: Commands,
     roots: Query<(Entity, &CollapsedSubScene)>,
     type_registry: Res<AppTypeRegistry>,
-    mut toast: EventWriter<ToastMessage>,
+    #[cfg(feature = "editor")] mut toast: EventWriter<ToastMessage>,
 ) {
     for (root_entity, root) in roots.iter() {
         let scene_deserializer = SceneDeserializer {
             type_registry: &type_registry.read(),
         };
         let Ok(mut deserializer) = ron::de::Deserializer::from_str(root.0.as_str()) else {
+            #[cfg(feature = "editor")]
             toast.send(ToastMessage::new(
                 "Failed create Deserializer for sub scene",
                 space_shared::toast::ToastKind::Error,
@@ -159,6 +161,7 @@ fn decompress_scene(
             continue;
         };
         let Ok(dyn_scene) = scene_deserializer.deserialize(&mut deserializer) else {
+            #[cfg(feature = "editor")]
             toast.send(ToastMessage::new(
                 "Failed to deserialize sub scene",
                 space_shared::toast::ToastKind::Error,
@@ -167,6 +170,7 @@ fn decompress_scene(
         };
 
         let Ok(scene) = Scene::from_dynamic_scene(&dyn_scene, &type_registry) else {
+            #[cfg(feature = "editor")]
             toast.send(ToastMessage::new(
                 "Decompress scene does not exist",
                 space_shared::toast::ToastKind::Error,
@@ -260,6 +264,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "editor")]
     fn decompress_scene_trows_event_when_missing_subscene() {
         let file = "test.ron";
 

--- a/examples/loading_test.rs
+++ b/examples/loading_test.rs
@@ -1,0 +1,18 @@
+use bevy::prelude::*;
+use space_editor::prelude::*;
+
+fn main() {
+    App::default()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(SpaceEditorPlugin)
+        .add_systems(Startup, simple_editor_setup)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, _assets: Res<AssetServer>) {
+    // prefab loaded by adding PrefabLoader component to any entity (it will be parent of prefab) or with prefab bundle
+    commands
+        .spawn(PrefabBundle::new("scenes/load_test.scn.ron"))
+        .insert(Name::new("Prefab"));
+}


### PR DESCRIPTION
- Button `|<<` had to be removed, the functionality is no longer available
- Clears Inspector and Hierarchy Filters
- Shapes are now spawnable and visible (Size was too small)
- Fixed some scenes, but scenes hierarchies seem to be incorrect due to new hashing loginc