### PR TITLE
`Add Component` button size

### DIFF
--- a/crates/editor_ui/src/hierarchy.rs
+++ b/crates/editor_ui/src/hierarchy.rs
@@ -83,7 +83,7 @@ pub fn show_hierarchy(
     ui.horizontal(|ui| {
         let width = ui.available_width() * 0.85;
         ui.add(TextEdit::singleline(&mut state.entity_filter).desired_width(width));
-        if ui.button("🗑").on_hover_text("Clear test").clicked() {
+        if ui.button("🗑").on_hover_text("Clear filter").clicked() {
             state.entity_filter.clear();
         }
     });


### PR DESCRIPTION
- Add Component default size is calculated as early as possible to prevent long components changing its size
- Fix typo in clear filter (clear test => clear filter) 
- Only transform component is open by default

https://github.com/rewin123/space_editor/issues/255