### PR TITLE
Improve debug compilation time

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Ctarget-cpu=native"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Install stable@stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --all-features --release
+        run: cargo test --workspace --all-features --release -- -C target-cpu=native
 
   # Run cargo clippy -- -D warnings
   clippy_check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev 
       - name: Run cargo test
-        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --no-default-features --release
+        run: cargo test --workspace --no-default-features --release
     
   test_all:
     name: Test all features
@@ -72,7 +72,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Run cargo test
-        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --all-features --release
+        run: cargo test --workspace --all-features --release
   
   test_all_macos:
     strategy:
@@ -97,7 +97,7 @@ jobs:
       - name: Install stable@stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        run: cargo test --workspace --all-features --release -- -C target-cpu=native
+        run: cargo test --workspace --all-features --release
 
   # Run cargo clippy -- -D warnings
   clippy_check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev 
       - name: Run cargo test
-        run: cargo test --workspace --no-default-features --release
+        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --no-default-features --release
     
   test_all:
     name: Test all features
@@ -72,7 +72,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Run cargo test
-        run: cargo test --workspace --all-features --release
+        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --all-features --release
   
   test_all_macos:
     strategy:
@@ -97,7 +97,7 @@ jobs:
       - name: Install stable@stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        run: cargo test --workspace --all-features --release
+        run: RUSTFLAGS="-C target-cpu=native" cargo test --workspace --all-features --release
 
   # Run cargo clippy -- -D warnings
   clippy_check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ too_many_arguments = { level = "allow", priority = 2 }
 [lints]
 workspace = true
 
-[profile.dev] #243.439463 s
+[profile.dev]
 opt-level = 0
 debug = "line-tables-only" 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,9 @@ too_many_arguments = { level = "allow", priority = 2 }
 [lints]
 workspace = true
 
-[profile.dev]
-opt-level = 1
+[profile.dev] #243.439463 s
+opt-level = 0
+debug = "line-tables-only" 
 
 [profile.dev.package."*"]
 opt-level = 3


### PR DESCRIPTION
Reduces compilation time for Debug mode:
| version | Compilation time | Caveats |
| --- | --- | --- |
| Old | 337.9357205 s | None |
| New | 243.439463 s | Compiles only to native version, so [no retro compatibility](https://nnethercote.github.io/perf-book/build-configuration.html#cpu-specific-instructions) |
 